### PR TITLE
Shell scripting support

### DIFF
--- a/duct-tape/Cargo.toml
+++ b/duct-tape/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "duct-tape"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+duct = "0.13.5"

--- a/duct-tape/README.md
+++ b/duct-tape/README.md
@@ -1,0 +1,22 @@
+#Duct Tape
+
+In the legendary [Knuth v McIlroy word count competition](http://www.leancrew.com/all-this/2011/12/more-shell-less-egg/), most would say the shell won.
+
+These are examples of interfacing with the [AWS CLI](https://github.com/aws/aws-cli), or the shell in general, to get things done.
+
+
+```bash
+
+## Sign an S3 bucket so it can be shared
+aws s3 presign s3://awsexamplebucket/test2.txt --expires-in 604800
+
+## Delelop on a remote EC2 instance 
+aws ec2 start-instances i-INSTANCE_ID
+aws ec2 describe-instances # TODO pipe to jq to get IP address
+ssh  username@INSTANCE_IP       -i keyfile   # alternatively connect with vscode
+# shut down for the day
+aws ec2 stop-instances --instance-ids i-INSTANCE_ID
+```
+
+
+

--- a/duct-tape/README.md
+++ b/duct-tape/README.md
@@ -1,4 +1,4 @@
-#Duct Tape
+# Duct Tape
 
 In the legendary [Knuth v McIlroy word count competition](http://www.leancrew.com/all-this/2011/12/more-shell-less-egg/), most would say the shell won.
 

--- a/duct-tape/README.md
+++ b/duct-tape/README.md
@@ -13,7 +13,7 @@ aws s3 presign s3://awsexamplebucket/test2.txt --expires-in 604800
 ## Delelop on a remote EC2 instance 
 aws ec2 start-instances i-INSTANCE_ID
 aws ec2 describe-instances # TODO pipe to jq to get IP address
-ssh  username@INSTANCE_IP       -i keyfile   # alternatively connect with vscode
+ssh  username@INSTANCE_IP -i keyfile # alternatively connect with vscode
 # shut down for the day
 aws ec2 stop-instances --instance-ids i-INSTANCE_ID
 ```

--- a/duct-tape/src/main.rs
+++ b/duct-tape/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/duct-tape/src/main.rs
+++ b/duct-tape/src/main.rs
@@ -1,3 +1,6 @@
+use duct::cmd;
+
 fn main() {
-    println!("Hello, world!");
+   let stdout = cmd!("aws", "--version").read();
+   assert_eq!(stdout.unwrap(), "llama");
 }


### PR DESCRIPTION
*Issue #, if available:*
It is going to take a while for the SDK to support all features, and even when it does scripting will still be better than Rust for several tasks.

*Description of changes:*

Adds a directory for AWS CLI scripting with a minimal example.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
