### PR TITLE
feat(aws-endpoint): add AwsEndpoint constructor

### DIFF
--- a/sdk/aws-endpoint/src/lib.rs
+++ b/sdk/aws-endpoint/src/lib.rs
@@ -34,6 +34,18 @@ pub struct AwsEndpoint {
 }
 
 impl AwsEndpoint {
+    pub fn new(
+        endpoint: Endpoint,
+        signing_service: impl Into<Option<SigningService>>,
+        signing_region: impl Into<Option<SigningRegion>>,
+    ) -> Self {
+        AwsEndpoint {
+            endpoint,
+            signing_service: signing_service.into(),
+            signing_region: signing_region.into(),
+        }
+    }
+
     pub fn set_endpoint(&self, mut uri: &mut http::Uri, endpoint_prefix: Option<&EndpointPrefix>) {
         self.endpoint.set_endpoint(&mut uri, endpoint_prefix);
     }


### PR DESCRIPTION
To implement new endpoint resolvers as other modules (in specific
`secretsmanagers` in my use-case), we need the ability to construct
`AwsEndpoint` instances. This was not possible due to the fields being
private, and there was no associated function for construction.

By submitting this pull request, I confirm that you can use, modify, copy,
and redistribute this contribution, under the terms of your choice.
