### PR TITLE
Add link to the WAFv2 service support issue

### DIFF
--- a/AWS_SERVICES_SUPPORTED.md
+++ b/AWS_SERVICES_SUPPORTED.md
@@ -235,7 +235,7 @@ The alpha SDK for Rust currently supports the checked services below. If you wan
 - [ ] Amazon Translate
 - [ ] Amazon Waf
 - [ ] Amazon Waf-Regional
-- [ ] Amazon Wafv2
+- [ ] [Amazon Wafv2](https://github.com/awslabs/aws-sdk-rust/issues/118)
 - [ ] Amazon Workdocs
 - [ ] Amazon Worklink
 - [ ] Amazon Workmail


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-sdk-rust/issues/118

*Description of changes:* Adds link to the WAFv2 service support issue


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
