### PR TITLE
Set up nightly `cargo audit` run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,3 +30,17 @@ jobs:
         env:
           CARGO_INCREMENTAL: 'false'
         working-directory: sdk
+
+  audit:
+    name: Cargo dependency security audit
+    on:
+      schedule:
+        - cron: '0 0 * * *'
+    jobs:
+      audit:
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v1
+          - uses: actions-rs/audit-check@v1
+            with:
+              token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This should resolve smithy-rs#271 since it will run `cargo audit` nightly on all the Rust runtime crate dependencies as well as on any code generated dependencies.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
