### PR TITLE
Check Docs Generation on PRs, fix docs generation

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,6 +1,7 @@
 on: 
   push:
     branches: [main]
+  pull_request:  
     
 env:
   rust_version: 1.51.0
@@ -21,7 +22,8 @@ jobs:
         env: 
           RUSTDOCFLAGS: "--enable-index-page -Zunstable-options"
         working-directory: sdk
-      - name: Push the docs 
+      - name: Push the docs
+        if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           ls
           git checkout -B gh-pages

--- a/sdk/smithy-types/src/instant/mod.rs
+++ b/sdk/smithy-types/src/instant/mod.rs
@@ -147,7 +147,8 @@ impl Instant {
     /// This is fallible since `Instant` holds more precision than an `i64`, and will
     /// return a `ConversionError` for `Instant` values that can't be converted.
     pub fn to_epoch_millis(&self) -> Result<i64, ConversionError> {
-        let subsec_millis = i64::from(self.subsecond_nanos).div_floor(&(NANOS_PER_MILLI as i64));
+        let subsec_millis =
+            Integer::div_floor(&i64::from(self.subsecond_nanos), &(NANOS_PER_MILLI as i64));
         if self.seconds < 0 {
             self.seconds
                 .checked_add(1)


### PR DESCRIPTION
*Issue #, if available:* smithy-rs#700

*Description of changes:* The runtime stopped compiling on nightly, but the docs use nightly to access unstable features. This updates CI so that PRs will validate that docs build properly & fixes the nightly compilation issue.

We will need to cut a new release to fix nightly compilation of the SDK.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
