### PR TITLE
Add lint for CVE-2021-42574 and change CI cache mechanism

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,22 +11,39 @@ jobs:
     name: Compile & Test SDK
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        name: Cargo Cache
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            sdk/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ env.rust_version }}
           default: true
+      # Pinned to the commit hash of v1.3.0
+      - uses: Swatinem/rust-cache@842ef286fff290e445b90b4002cc9807c3669641
+        with:
+          sharedKey: test
+          working-directory: sdk
       - name: Cargo Test
         run: cargo test
+        env:
+          CARGO_INCREMENTAL: 'false'
+        working-directory: sdk
+
+  # Check for CVE-2021-42574 using Rust 1.56.1 which added the lints.
+  # Once our MSRV is >= 1.56.1, this job can be removed.
+  cve-2021-42574:
+    runs-on: ubuntu-latest
+    name: Check for CVE-2021-42574
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.56.1
+          default: true
+      # Pinned to the commit hash of v1.3.0
+      - uses: Swatinem/rust-cache@842ef286fff290e445b90b4002cc9807c3669641
+        with:
+          sharedKey: cve-2021-42574
+          working-directory: sdk
+      - name: Cargo Check
+        run: cargo check
         env:
           CARGO_INCREMENTAL: 'false'
         working-directory: sdk

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,19 +1,18 @@
 on: [ pull_request ]
 
-env:
-  rust_version: 1.53.0
-
 name: CI
 
 jobs:
   test:
     runs-on: ubuntu-latest
     name: Compile & Test SDK
+    strategy:
+      rust_version: [1.53.0, 1.56.1]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env.rust_version }}
+          toolchain: ${{ matrix.rust_version }}
           default: true
       # Pinned to the commit hash of v1.3.0
       - uses: Swatinem/rust-cache@842ef286fff290e445b90b4002cc9807c3669641
@@ -22,28 +21,6 @@ jobs:
           working-directory: sdk
       - name: Cargo Test
         run: cargo test
-        env:
-          CARGO_INCREMENTAL: 'false'
-        working-directory: sdk
-
-  # Check for CVE-2021-42574 using Rust 1.56.1 which added the lints.
-  # Once our MSRV is >= 1.56.1, this job can be removed.
-  cve-2021-42574:
-    runs-on: ubuntu-latest
-    name: Check for CVE-2021-42574
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.56.1
-          default: true
-      # Pinned to the commit hash of v1.3.0
-      - uses: Swatinem/rust-cache@842ef286fff290e445b90b4002cc9807c3669641
-        with:
-          sharedKey: cve-2021-42574
-          working-directory: sdk
-      - name: Cargo Check
-        run: cargo check
         env:
           CARGO_INCREMENTAL: 'false'
         working-directory: sdk

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Compile & Test SDK
     strategy:
-      rust_version: [1.53.0, 1.56.1]
+      matrix:
+        rust_version: [1.53.0, 1.56.1]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/tool-ci.yaml
+++ b/.github/workflows/tool-ci.yaml
@@ -3,7 +3,9 @@ on:
     paths: 'tools/**'
 
 env:
-  rust_version: 1.53.0
+  # The publisher tool can use the latest Rust since it isn't published
+  # Build with a minimum of Rust 1.56.1 to check for CVE-2021-42574.
+  rust_version: 1.56.1
   rust_toolchain_components: clippy,rustfmt
 
 name: Tools CI
@@ -14,21 +16,16 @@ jobs:
     name: Compile, Test, and Lint the `tools/` path
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        name: Cargo Cache
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            tools/publisher/target
-          key: tools-${{ runner.os }}-cargo-${{ hashFiles('tools/**/Cargo.toml') }}
-          restore-keys: |
-            tools-${{ runner.os }}-cargo-
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ env.rust_version }}
           components: ${{ env.rust_toolchain_components }}
           default: true
+      # Pinned to the commit hash of v1.3.0
+      - uses: Swatinem/rust-cache@842ef286fff290e445b90b4002cc9807c3669641
+        with:
+          sharedKey: tools-test
+          working-directory: tools/publisher
       - name: Format Check
         run: rustfmt --check --edition 2018 $(find tools -name '*.rs' -print | grep -v /target/)
       - name: Cargo Test

--- a/.github/workflows/tool-ci.yaml
+++ b/.github/workflows/tool-ci.yaml
@@ -3,7 +3,7 @@ on:
     paths: 'tools/**'
 
 env:
-  # The publisher tool can use the latest Rust since it isn't published
+  # The publisher tool can use the latest Rust since it isn't published.
   # Build with a minimum of Rust 1.56.1 to check for CVE-2021-42574.
   rust_version: 1.56.1
   rust_toolchain_components: clippy,rustfmt


### PR DESCRIPTION
This adds a CI job that runs `cargo check` against Rust 1.56.1 to safeguard against CVE-2021-42574. More information: https://blog.rust-lang.org/2021/11/01/cve-2021-42574.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
