### PR TITLE
Fix examples folder link

### DIFF
--- a/sdk/accessanalyzer/README.md
+++ b/sdk/accessanalyzer/README.md
@@ -10,7 +10,7 @@ To start using IAM Access Analyzer, you first need to create an analyzer.
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-accessanalyzer` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/account/README.md
+++ b/sdk/account/README.md
@@ -8,7 +8,7 @@ Operations for Amazon Web Services Account Management
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-account` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/acm/README.md
+++ b/sdk/acm/README.md
@@ -8,7 +8,7 @@ You can use Amazon Web Services Certificate Manager (ACM) to manage SSL/TLS cert
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-acm` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/acmpca/README.md
+++ b/sdk/acmpca/README.md
@@ -14,7 +14,7 @@ To see an up-to-date list of your ACM Private CA quotas, or to request a quota i
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-acmpca` to
@@ -38,7 +38,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/alexaforbusiness/README.md
+++ b/sdk/alexaforbusiness/README.md
@@ -8,7 +8,7 @@ Alexa for Business helps you use Alexa in your organization. Alexa for Business 
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-alexaforbusiness` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/amp/README.md
+++ b/sdk/amp/README.md
@@ -8,7 +8,7 @@ Amazon Managed Service for Prometheus
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-amp` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/amplify/README.md
+++ b/sdk/amplify/README.md
@@ -8,7 +8,7 @@ Amplify enables developers to develop and deploy cloud-powered mobile and web ap
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-amplify` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/amplifybackend/README.md
+++ b/sdk/amplifybackend/README.md
@@ -8,7 +8,7 @@ AWS Amplify Admin API
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-amplifybackend` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/apigateway/README.md
+++ b/sdk/apigateway/README.md
@@ -8,7 +8,7 @@ Amazon API Gateway helps developers deliver robust, secure, and scalable mobile 
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-apigateway` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/apigatewaymanagement/README.md
+++ b/sdk/apigatewaymanagement/README.md
@@ -8,7 +8,7 @@ The Amazon API Gateway Management API allows you to directly manage runtime aspe
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-apigatewaymanagement` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/apigatewayv2/README.md
+++ b/sdk/apigatewayv2/README.md
@@ -8,7 +8,7 @@ Amazon API Gateway V2
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-apigatewayv2` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/appconfig/README.md
+++ b/sdk/appconfig/README.md
@@ -20,7 +20,7 @@ This reference is intended to be used with the [AWS AppConfig User Guide](http:/
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-appconfig` to
@@ -44,7 +44,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/appflow/README.md
+++ b/sdk/appflow/README.md
@@ -20,7 +20,7 @@ Amazon AppFlow API users can use vendor-specific mechanisms for OAuth, and inclu
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-appflow` to
@@ -44,7 +44,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/appintegrations/README.md
+++ b/sdk/appintegrations/README.md
@@ -10,7 +10,7 @@ For information about how you can use external applications with Amazon Connect,
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-appintegrations` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/applicationautoscaling/README.md
+++ b/sdk/applicationautoscaling/README.md
@@ -31,7 +31,7 @@ To learn more about Application Auto Scaling, including information about granti
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-applicationautoscaling` to
@@ -55,7 +55,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/applicationcostprofiler/README.md
+++ b/sdk/applicationcostprofiler/README.md
@@ -12,7 +12,7 @@ For more information about using this service, see the [AWS Application Cost Pro
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-applicationcostprofiler` to
@@ -36,7 +36,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/applicationdiscovery/README.md
+++ b/sdk/applicationdiscovery/README.md
@@ -31,7 +31,7 @@ All data is handled according to the [AWS Privacy Policy](http://aws.amazon.com/
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-applicationdiscovery` to
@@ -55,7 +55,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/applicationinsights/README.md
+++ b/sdk/applicationinsights/README.md
@@ -10,7 +10,7 @@ After you onboard your application, CloudWatch Application Insights identifies, 
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-applicationinsights` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/appmesh/README.md
+++ b/sdk/appmesh/README.md
@@ -10,7 +10,7 @@ App Mesh gives you consistent visibility and network traffic controls for every 
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-appmesh` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/apprunner/README.md
+++ b/sdk/apprunner/README.md
@@ -18,7 +18,7 @@ For a list of Region-specific endpoints that App Runner supports, see [App Runne
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-apprunner` to
@@ -42,7 +42,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/appstream/README.md
+++ b/sdk/appstream/README.md
@@ -12,7 +12,7 @@ To learn more about AppStream 2.0, see the following resources:
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-appstream` to
@@ -36,7 +36,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/appsync/README.md
+++ b/sdk/appsync/README.md
@@ -8,7 +8,7 @@ AppSync provides API actions for creating and interacting with data sources usin
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-appsync` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/athena/README.md
+++ b/sdk/athena/README.md
@@ -12,7 +12,7 @@ For code samples using the Amazon Web Services SDK for Java, see [Examples and C
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-athena` to
@@ -36,7 +36,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/auditmanager/README.md
+++ b/sdk/auditmanager/README.md
@@ -20,7 +20,7 @@ If you're new to Audit Manager, we recommend that you review the [Audit Manager 
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-auditmanager` to
@@ -44,7 +44,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/autoscaling/README.md
+++ b/sdk/autoscaling/README.md
@@ -10,7 +10,7 @@ For more information about Amazon EC2 Auto Scaling, see the [Amazon EC2 Auto Sca
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-autoscaling` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/autoscalingplans/README.md
+++ b/sdk/autoscalingplans/README.md
@@ -20,7 +20,7 @@ To learn more about AWS Auto Scaling, including information about granting IAM u
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-autoscalingplans` to
@@ -44,7 +44,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/backup/README.md
+++ b/sdk/backup/README.md
@@ -8,7 +8,7 @@ Backup is a unified backup service designed to protect Amazon Web Services servi
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-backup` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/batch/README.md
+++ b/sdk/batch/README.md
@@ -10,7 +10,7 @@ As a fully managed service, Batch can run batch computing workloads of any scale
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-batch` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/braket/README.md
+++ b/sdk/braket/README.md
@@ -8,7 +8,7 @@ The Amazon Braket API Reference provides information about the operations and st
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-braket` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/budgets/README.md
+++ b/sdk/budgets/README.md
@@ -27,7 +27,7 @@ For information about costs that are associated with the AWS Budgets API, see [A
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-budgets` to
@@ -51,7 +51,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/chime/README.md
+++ b/sdk/chime/README.md
@@ -25,7 +25,7 @@ Administrative permissions are controlled using AWS Identity and Access Manageme
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-chime` to
@@ -49,7 +49,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/chimesdkidentity/README.md
+++ b/sdk/chimesdkidentity/README.md
@@ -8,7 +8,7 @@ The Amazon Chime SDK Identity APIs in this section allow software developers to 
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-chimesdkidentity` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/chimesdkmessaging/README.md
+++ b/sdk/chimesdkmessaging/README.md
@@ -8,7 +8,7 @@ The Amazon Chime SDK Messaging APIs in this section allow software developers to
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-chimesdkmessaging` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/cloud9/README.md
+++ b/sdk/cloud9/README.md
@@ -25,7 +25,7 @@ Cloud9 supports these operations:
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-cloud9` to
@@ -49,7 +49,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/cloudcontrol/README.md
+++ b/sdk/cloudcontrol/README.md
@@ -10,7 +10,7 @@ For more information about Amazon Web Services Cloud Control API, see the [Amazo
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-cloudcontrol` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/clouddirectory/README.md
+++ b/sdk/clouddirectory/README.md
@@ -8,7 +8,7 @@ Amazon Cloud Directory is a component of the AWS Directory Service that simplifi
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-clouddirectory` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/cloudformation/README.md
+++ b/sdk/cloudformation/README.md
@@ -14,7 +14,7 @@ CloudFormation makes use of other Amazon Web Services products. If you need addi
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-cloudformation` to
@@ -38,7 +38,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/cloudfront/README.md
+++ b/sdk/cloudfront/README.md
@@ -8,7 +8,7 @@ This is the _Amazon CloudFront API Reference_. This guide is for developers who 
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-cloudfront` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/cloudhsm/README.md
+++ b/sdk/cloudhsm/README.md
@@ -10,7 +10,7 @@ __For information about the current version of AWS CloudHSM__, see [AWS CloudHSM
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-cloudhsm` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/cloudhsmv2/README.md
+++ b/sdk/cloudhsmv2/README.md
@@ -8,7 +8,7 @@ For more information about AWS CloudHSM, see [AWS CloudHSM](http://aws.amazon.co
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-cloudhsmv2` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/cloudsearch/README.md
+++ b/sdk/cloudsearch/README.md
@@ -10,7 +10,7 @@ The endpoint for configuration service requests is region-specific: cloudsearch.
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-cloudsearch` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/cloudsearchdomain/README.md
+++ b/sdk/cloudsearchdomain/README.md
@@ -12,7 +12,7 @@ For more information, see the [Amazon CloudSearch Developer Guide](http://docs.a
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-cloudsearchdomain` to
@@ -36,7 +36,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/cloudtrail/README.md
+++ b/sdk/cloudtrail/README.md
@@ -12,7 +12,7 @@ See the [CloudTrail User Guide](https://docs.aws.amazon.com/awscloudtrail/latest
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-cloudtrail` to
@@ -36,7 +36,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/cloudwatch/README.md
+++ b/sdk/cloudwatch/README.md
@@ -12,7 +12,7 @@ In addition to monitoring the built-in metrics that come with Amazon Web Service
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-cloudwatch` to
@@ -36,7 +36,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/cloudwatchevents/README.md
+++ b/sdk/cloudwatchevents/README.md
@@ -13,7 +13,7 @@ For more information about the features of Amazon EventBridge, see the [Amazon E
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-cloudwatchevents` to
@@ -37,7 +37,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/cloudwatchlogs/README.md
+++ b/sdk/cloudwatchlogs/README.md
@@ -13,7 +13,7 @@ You can use CloudWatch Logs to:
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-cloudwatchlogs` to
@@ -37,7 +37,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/codeartifact/README.md
+++ b/sdk/codeartifact/README.md
@@ -60,7 +60,7 @@ CodeArtifact supports these operations:
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-codeartifact` to
@@ -84,7 +84,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/codebuild/README.md
+++ b/sdk/codebuild/README.md
@@ -8,7 +8,7 @@ CodeBuild is a fully managed build service in the cloud. CodeBuild compiles your
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-codebuild` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/codecommit/README.md
+++ b/sdk/codecommit/README.md
@@ -109,7 +109,7 @@ For information about how to use AWS CodeCommit, see the [AWS CodeCommit User Gu
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-codecommit` to
@@ -133,7 +133,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/codedeploy/README.md
+++ b/sdk/codedeploy/README.md
@@ -29,7 +29,7 @@ __AWS CodeDeploy Information Resources__
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-codedeploy` to
@@ -53,7 +53,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/codeguruprofiler/README.md
+++ b/sdk/codeguruprofiler/README.md
@@ -14,7 +14,7 @@ For more information, see [What is Amazon CodeGuru Profiler](https://docs.aws.am
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-codeguruprofiler` to
@@ -38,7 +38,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/codegurureviewer/README.md
+++ b/sdk/codegurureviewer/README.md
@@ -12,7 +12,7 @@ To improve the security of your CodeGuru Reviewer API calls, you can establish a
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-codegurureviewer` to
@@ -36,7 +36,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/codepipeline/README.md
+++ b/sdk/codepipeline/README.md
@@ -65,7 +65,7 @@ You can work with third party jobs by calling:
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-codepipeline` to
@@ -89,7 +89,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/codestar/README.md
+++ b/sdk/codestar/README.md
@@ -33,7 +33,7 @@ Users, by calling the following:
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-codestar` to
@@ -57,7 +57,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/codestarconnections/README.md
+++ b/sdk/codestarconnections/README.md
@@ -33,7 +33,7 @@ For information about how to use AWS CodeStar Connections, see the [Developer To
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-codestarconnections` to
@@ -57,7 +57,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/codestarnotifications/README.md
+++ b/sdk/codestarnotifications/README.md
@@ -31,7 +31,7 @@ For information about how to use AWS CodeStar Notifications, see link in the Cod
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-codestarnotifications` to
@@ -55,7 +55,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/cognitoidentity/README.md
+++ b/sdk/cognitoidentity/README.md
@@ -14,7 +14,7 @@ For more information see [Amazon Cognito Federated Identities](https://docs.aws.
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-cognitoidentity` to
@@ -38,7 +38,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/cognitoidentityprovider/README.md
+++ b/sdk/cognitoidentityprovider/README.md
@@ -12,7 +12,7 @@ For more information, see the [Amazon Cognito Documentation](https://docs.aws.am
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-cognitoidentityprovider` to
@@ -36,7 +36,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/cognitosync/README.md
+++ b/sdk/cognitosync/README.md
@@ -12,7 +12,7 @@ If you want to use Cognito Sync in an Android or iOS application, you will proba
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-cognitosync` to
@@ -36,7 +36,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/comprehend/README.md
+++ b/sdk/comprehend/README.md
@@ -8,7 +8,7 @@ Amazon Comprehend is an AWS service for gaining insight into the content of docu
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-comprehend` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/comprehendmedical/README.md
+++ b/sdk/comprehendmedical/README.md
@@ -8,7 +8,7 @@ Amazon Comprehend Medical extracts structured information from unstructured clin
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-comprehendmedical` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/computeoptimizer/README.md
+++ b/sdk/computeoptimizer/README.md
@@ -8,7 +8,7 @@ Compute Optimizer is a service that analyzes the configuration and utilization m
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-computeoptimizer` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/config/README.md
+++ b/sdk/config/README.md
@@ -10,7 +10,7 @@ You can access and manage Config through the Amazon Web Services Management Cons
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-config` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/connect/README.md
+++ b/sdk/connect/README.md
@@ -14,7 +14,7 @@ You can connect programmatically to an AWS service by using an endpoint. For a l
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-connect` to
@@ -38,7 +38,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/connectcontactlens/README.md
+++ b/sdk/connectcontactlens/README.md
@@ -10,7 +10,7 @@ Contact Lens for Amazon Connect provides both real-time and post-call analytics 
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-connectcontactlens` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/connectparticipant/README.md
+++ b/sdk/connectparticipant/README.md
@@ -12,7 +12,7 @@ The APIs described here are used by chat participants, such as agents and custom
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-connectparticipant` to
@@ -36,7 +36,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/costandusagereport/README.md
+++ b/sdk/costandusagereport/README.md
@@ -15,7 +15,7 @@ The AWS Cost and Usage Report API provides the following endpoint:
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-costandusagereport` to
@@ -39,7 +39,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/costexplorer/README.md
+++ b/sdk/costexplorer/README.md
@@ -15,7 +15,7 @@ For information about the costs that are associated with the Cost Explorer API, 
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-costexplorer` to
@@ -39,7 +39,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/customerprofiles/README.md
+++ b/sdk/customerprofiles/README.md
@@ -12,7 +12,7 @@ If you're new to Amazon Connect , you might find it helpful to also review the [
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-customerprofiles` to
@@ -36,7 +36,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/databasemigration/README.md
+++ b/sdk/databasemigration/README.md
@@ -10,7 +10,7 @@ For more information about DMS, see [What Is Database Migration Service?](https:
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-databasemigration` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/databrew/README.md
+++ b/sdk/databrew/README.md
@@ -8,7 +8,7 @@ Glue DataBrew is a visual, cloud-scale data-preparation service. DataBrew simpli
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-databrew` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/dataexchange/README.md
+++ b/sdk/dataexchange/README.md
@@ -14,7 +14,7 @@ A data set is a collection of data that can be changed or updated over time. Dat
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-dataexchange` to
@@ -38,7 +38,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/datapipeline/README.md
+++ b/sdk/datapipeline/README.md
@@ -12,7 +12,7 @@ AWS Data Pipeline implements two main sets of functionality. Use the first set t
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-datapipeline` to
@@ -36,7 +36,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/datasync/README.md
+++ b/sdk/datasync/README.md
@@ -10,7 +10,7 @@ This API interface reference for DataSync contains documentation for a programmi
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-datasync` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/dax/README.md
+++ b/sdk/dax/README.md
@@ -8,7 +8,7 @@ DAX is a managed caching service engineered for Amazon DynamoDB. DAX dramaticall
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-dax` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/detective/README.md
+++ b/sdk/detective/README.md
@@ -26,7 +26,7 @@ All API actions are logged as CloudTrail events. See [Logging Detective API Call
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-detective` to
@@ -50,7 +50,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/devicefarm/README.md
+++ b/sdk/devicefarm/README.md
@@ -10,7 +10,7 @@ Welcome to the AWS Device Farm API documentation, which contains APIs for:
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-devicefarm` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/devopsguru/README.md
+++ b/sdk/devopsguru/README.md
@@ -12,7 +12,7 @@ To learn about the DevOps Guru workflow, see [How DevOps Guru works](https://doc
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-devopsguru` to
@@ -36,7 +36,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/directconnect/README.md
+++ b/sdk/directconnect/README.md
@@ -8,7 +8,7 @@ Direct Connect links your internal network to an Direct Connect location over a 
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-directconnect` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/directory/README.md
+++ b/sdk/directory/README.md
@@ -8,7 +8,7 @@ Directory Service is a web service that makes it easy for you to setup and run d
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-directory` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/dlm/README.md
+++ b/sdk/dlm/README.md
@@ -10,7 +10,7 @@ Amazon DLM supports Amazon EBS volumes and snapshots. For information about usin
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-dlm` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/docdb/README.md
+++ b/sdk/docdb/README.md
@@ -8,7 +8,7 @@ Amazon DocumentDB API documentation
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-docdb` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/dynamodb/README.md
+++ b/sdk/dynamodb/README.md
@@ -12,7 +12,7 @@ DynamoDB automatically spreads the data and traffic for your tables over a suffi
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-dynamodb` to
@@ -36,7 +36,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/dynamodbstreams/README.md
+++ b/sdk/dynamodbstreams/README.md
@@ -8,7 +8,7 @@ Amazon DynamoDB Streams provides API actions for accessing streams and processin
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-dynamodbstreams` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/ebs/README.md
+++ b/sdk/ebs/README.md
@@ -12,7 +12,7 @@ This API reference provides detailed information about the actions, data types, 
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-ebs` to
@@ -36,7 +36,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/ec2/README.md
+++ b/sdk/ec2/README.md
@@ -14,7 +14,7 @@ To learn more, see the following resources:
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-ec2` to
@@ -38,7 +38,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/ec2instanceconnect/README.md
+++ b/sdk/ec2instanceconnect/README.md
@@ -8,7 +8,7 @@ Amazon EC2 Instance Connect enables system administrators to publish one-time us
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-ec2instanceconnect` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/ecr/README.md
+++ b/sdk/ecr/README.md
@@ -10,7 +10,7 @@ Amazon ECR has service endpoints in each supported Region. For more information,
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-ecr` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/ecrpublic/README.md
+++ b/sdk/ecrpublic/README.md
@@ -8,7 +8,7 @@ Amazon Elastic Container Registry (Amazon ECR) is a managed container image regi
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-ecrpublic` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/ecs/README.md
+++ b/sdk/ecs/README.md
@@ -12,7 +12,7 @@ You can use Amazon ECS to schedule the placement of containers across your clust
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-ecs` to
@@ -36,7 +36,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/efs/README.md
+++ b/sdk/efs/README.md
@@ -8,7 +8,7 @@ Amazon Elastic File System (Amazon EFS) provides simple, scalable file storage f
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-efs` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/eks/README.md
+++ b/sdk/eks/README.md
@@ -10,7 +10,7 @@ Amazon EKS runs up-to-date versions of the open-source Kubernetes software, so y
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-eks` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/elasticache/README.md
+++ b/sdk/elasticache/README.md
@@ -12,7 +12,7 @@ In addition, through integration with Amazon CloudWatch, customers get enhanced 
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-elasticache` to
@@ -36,7 +36,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/elasticbeanstalk/README.md
+++ b/sdk/elasticbeanstalk/README.md
@@ -14,7 +14,7 @@ For a list of region-specific endpoints that AWS Elastic Beanstalk supports, go 
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-elasticbeanstalk` to
@@ -38,7 +38,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/elasticinference/README.md
+++ b/sdk/elasticinference/README.md
@@ -8,7 +8,7 @@ Elastic Inference public APIs.
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-elasticinference` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/elasticloadbalancing/README.md
+++ b/sdk/elasticloadbalancing/README.md
@@ -16,7 +16,7 @@ All Elastic Load Balancing operations are _idempotent_, which means that they co
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-elasticloadbalancing` to
@@ -40,7 +40,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/elasticloadbalancingv2/README.md
+++ b/sdk/elasticloadbalancingv2/README.md
@@ -17,7 +17,7 @@ All Elastic Load Balancing operations are idempotent, which means that they comp
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-elasticloadbalancingv2` to
@@ -41,7 +41,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/elasticsearch/README.md
+++ b/sdk/elasticsearch/README.md
@@ -12,7 +12,7 @@ The endpoint for configuration service requests is region-specific: es._region_.
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-elasticsearch` to
@@ -36,7 +36,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/elastictranscoder/README.md
+++ b/sdk/elastictranscoder/README.md
@@ -8,7 +8,7 @@ The AWS Elastic Transcoder Service.
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-elastictranscoder` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/emr/README.md
+++ b/sdk/emr/README.md
@@ -8,7 +8,7 @@ Amazon EMR is a web service that makes it easier to process large amounts of dat
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-emr` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/emrcontainers/README.md
+++ b/sdk/emrcontainers/README.md
@@ -13,7 +13,7 @@ _Amazon EMR containers_ is the API name for Amazon EMR on EKS. The emr-container
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-emrcontainers` to
@@ -37,7 +37,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/eventbridge/README.md
+++ b/sdk/eventbridge/README.md
@@ -13,7 +13,7 @@ For more information about the features of Amazon EventBridge, see the [Amazon E
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-eventbridge` to
@@ -37,7 +37,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/finspace/README.md
+++ b/sdk/finspace/README.md
@@ -8,7 +8,7 @@ The FinSpace management service provides the APIs for managing the FinSpace envi
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-finspace` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/finspacedata/README.md
+++ b/sdk/finspacedata/README.md
@@ -8,7 +8,7 @@ The FinSpace APIs let you take actions inside the FinSpace environment.
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-finspacedata` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/firehose/README.md
+++ b/sdk/firehose/README.md
@@ -8,7 +8,7 @@ Amazon Kinesis Data Firehose is a fully managed service that delivers real-time 
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-firehose` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/fis/README.md
+++ b/sdk/fis/README.md
@@ -8,7 +8,7 @@ AWS Fault Injection Simulator is a managed service that enables you to perform f
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-fis` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/fms/README.md
+++ b/sdk/fms/README.md
@@ -10,7 +10,7 @@ Some API actions require explicit resource permissions. For information, see the
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-fms` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/forecast/README.md
+++ b/sdk/forecast/README.md
@@ -8,7 +8,7 @@ Provides APIs for creating and managing Amazon Forecast resources.
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-forecast` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/forecastquery/README.md
+++ b/sdk/forecastquery/README.md
@@ -8,7 +8,7 @@ Provides APIs for creating and managing Amazon Forecast resources.
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-forecastquery` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/frauddetector/README.md
+++ b/sdk/frauddetector/README.md
@@ -8,7 +8,7 @@ This is the Amazon Fraud Detector API Reference. This guide is for developers wh
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-frauddetector` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/fsx/README.md
+++ b/sdk/fsx/README.md
@@ -8,7 +8,7 @@ Amazon FSx is a fully managed service that makes it easy for storage and applica
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-fsx` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/gamelift/README.md
+++ b/sdk/gamelift/README.md
@@ -22,7 +22,7 @@ This reference guide describes the low-level service API for Amazon GameLift. Wi
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-gamelift` to
@@ -46,7 +46,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/glacier/README.md
+++ b/sdk/glacier/README.md
@@ -18,7 +18,7 @@ If you are a first-time user of Glacier, we recommend that you begin by reading 
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-glacier` to
@@ -42,7 +42,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/globalaccelerator/README.md
+++ b/sdk/globalaccelerator/README.md
@@ -54,7 +54,7 @@ An endpoint is a resource that Global Accelerator directs traffic to. Endpoints 
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-globalaccelerator` to
@@ -78,7 +78,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/glue/README.md
+++ b/sdk/glue/README.md
@@ -8,7 +8,7 @@ Defines the public endpoint for the Glue service.
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-glue` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/grafana/README.md
+++ b/sdk/grafana/README.md
@@ -10,7 +10,7 @@ With Amazon Managed Grafana, you create logically isolated Grafana servers calle
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-grafana` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/greengrass/README.md
+++ b/sdk/greengrass/README.md
@@ -8,7 +8,7 @@ AWS IoT Greengrass seamlessly extends AWS onto physical devices so they can act 
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-greengrass` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/greengrassv2/README.md
+++ b/sdk/greengrassv2/README.md
@@ -12,7 +12,7 @@ For more information, see [What is IoT Greengrass?](https://docs.aws.amazon.com/
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-greengrassv2` to
@@ -36,7 +36,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/groundstation/README.md
+++ b/sdk/groundstation/README.md
@@ -8,7 +8,7 @@ Welcome to the AWS Ground Station API Reference. AWS Ground Station is a fully m
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-groundstation` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/guardduty/README.md
+++ b/sdk/guardduty/README.md
@@ -12,7 +12,7 @@ GuardDuty informs you of the status of your AWS environment by producing securit
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-guardduty` to
@@ -36,7 +36,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/health/README.md
+++ b/sdk/health/README.md
@@ -12,7 +12,7 @@ If your AWS account is part of AWS Organizations, you can use the AWS Health org
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-health` to
@@ -36,7 +36,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/healthlake/README.md
+++ b/sdk/healthlake/README.md
@@ -8,7 +8,7 @@ Amazon HealthLake is a HIPAA eligibile service that allows customers to store, t
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-healthlake` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/honeycode/README.md
+++ b/sdk/honeycode/README.md
@@ -8,7 +8,7 @@ Amazon Honeycode is a fully managed service that allows you to quickly build mob
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-honeycode` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/iam/README.md
+++ b/sdk/iam/README.md
@@ -8,7 +8,7 @@ Identity and Access Management (IAM) is a web service for securely controlling a
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-iam` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/identitystore/README.md
+++ b/sdk/identitystore/README.md
@@ -8,7 +8,7 @@ The AWS Single Sign-On (SSO) Identity Store service provides a single place to r
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-identitystore` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/imagebuilder/README.md
+++ b/sdk/imagebuilder/README.md
@@ -8,7 +8,7 @@ EC2 Image Builder is a fully managed Amazon Web Services service that makes it e
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-imagebuilder` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/inspector/README.md
+++ b/sdk/inspector/README.md
@@ -8,7 +8,7 @@ Amazon Inspector enables you to analyze the behavior of your AWS resources and t
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-inspector` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/iot/README.md
+++ b/sdk/iot/README.md
@@ -16,7 +16,7 @@ For information about how to use the credentials provider for IoT, see [Authoriz
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-iot` to
@@ -40,7 +40,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/iot1clickdevices/README.md
+++ b/sdk/iot1clickdevices/README.md
@@ -8,7 +8,7 @@ Describes all of the AWS IoT 1-Click device-related API operations for the servi
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-iot1clickdevices` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/iot1clickprojects/README.md
+++ b/sdk/iot1clickprojects/README.md
@@ -8,7 +8,7 @@ The AWS IoT 1-Click Projects API Reference
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-iot1clickprojects` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/iotanalytics/README.md
+++ b/sdk/iotanalytics/README.md
@@ -12,7 +12,7 @@ IoT Analytics automates the steps required to analyze data from IoT devices. IoT
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-iotanalytics` to
@@ -36,7 +36,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/iotdataplane/README.md
+++ b/sdk/iotdataplane/README.md
@@ -14,7 +14,7 @@ The service name used by [Amazon Web ServicesSignature Version 4](https://docs.a
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-iotdataplane` to
@@ -38,7 +38,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/iotdeviceadvisor/README.md
+++ b/sdk/iotdeviceadvisor/README.md
@@ -8,7 +8,7 @@ AWS IoT Core Device Advisor is a cloud-based, fully managed test capability for 
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-iotdeviceadvisor` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/iotevents/README.md
+++ b/sdk/iotevents/README.md
@@ -8,7 +8,7 @@ AWS IoT Events monitors your equipment or device fleets for failures or changes 
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-iotevents` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/ioteventsdata/README.md
+++ b/sdk/ioteventsdata/README.md
@@ -10,7 +10,7 @@ For more information, see [What is AWS IoT Events?](https://docs.aws.amazon.com/
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-ioteventsdata` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/iotfleethub/README.md
+++ b/sdk/iotfleethub/README.md
@@ -8,7 +8,7 @@ With Fleet Hub for AWS IoT Device Management you can build stand-alone web appli
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-iotfleethub` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/iotjobsdataplane/README.md
+++ b/sdk/iotjobsdataplane/README.md
@@ -12,7 +12,7 @@ AWS IoT Jobs sends a message to inform the targets that a job is available. The 
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-iotjobsdataplane` to
@@ -36,7 +36,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/iotsecuretunneling/README.md
+++ b/sdk/iotsecuretunneling/README.md
@@ -10,7 +10,7 @@ For more information about how AWS IoT Secure Tunneling works, see [AWS IoT Secu
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-iotsecuretunneling` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/iotsitewise/README.md
+++ b/sdk/iotsitewise/README.md
@@ -8,7 +8,7 @@ Welcome to the IoT SiteWise API Reference. IoT SiteWise is an Amazon Web Service
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-iotsitewise` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/iotthingsgraph/README.md
+++ b/sdk/iotthingsgraph/README.md
@@ -10,7 +10,7 @@ For more information about how AWS IoT Things Graph works, see the [User Guide](
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-iotthingsgraph` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/iotwireless/README.md
+++ b/sdk/iotwireless/README.md
@@ -8,7 +8,7 @@ AWS IoT Wireless API documentation
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-iotwireless` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/ivs/README.md
+++ b/sdk/ivs/README.md
@@ -95,7 +95,7 @@ __Amazon Web Services Tags Endpoints__
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-ivs` to
@@ -119,7 +119,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/kafka/README.md
+++ b/sdk/kafka/README.md
@@ -8,7 +8,7 @@ The operations for managing an Amazon MSK cluster.
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-kafka` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/kafkaconnect/README.md
+++ b/sdk/kafkaconnect/README.md
@@ -8,7 +8,7 @@ feedback purposes only. Do not use this SDK for production workloads.**
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-kafkaconnect` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/kendra/README.md
+++ b/sdk/kendra/README.md
@@ -8,7 +8,7 @@ Amazon Kendra is a service for indexing large document sets.
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-kendra` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/kinesis/README.md
+++ b/sdk/kinesis/README.md
@@ -8,7 +8,7 @@ Amazon Kinesis Data Streams is a managed service that scales elastically for rea
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-kinesis` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/kinesisanalytics/README.md
+++ b/sdk/kinesisanalytics/README.md
@@ -10,7 +10,7 @@ This is the _Amazon Kinesis Analytics v1 API Reference_. The Amazon Kinesis Anal
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-kinesisanalytics` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/kinesisanalyticsv2/README.md
+++ b/sdk/kinesisanalyticsv2/README.md
@@ -8,7 +8,7 @@ Amazon Kinesis Data Analytics is a fully managed service that you can use to pro
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-kinesisanalyticsv2` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/kinesisvideo/README.md
+++ b/sdk/kinesisvideo/README.md
@@ -8,7 +8,7 @@ feedback purposes only. Do not use this SDK for production workloads.**
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-kinesisvideo` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/kinesisvideoarchivedmedia/README.md
+++ b/sdk/kinesisvideoarchivedmedia/README.md
@@ -8,7 +8,7 @@ feedback purposes only. Do not use this SDK for production workloads.**
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-kinesisvideoarchivedmedia` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/kinesisvideomedia/README.md
+++ b/sdk/kinesisvideomedia/README.md
@@ -8,7 +8,7 @@ feedback purposes only. Do not use this SDK for production workloads.**
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-kinesisvideomedia` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/kinesisvideosignaling/README.md
+++ b/sdk/kinesisvideosignaling/README.md
@@ -8,7 +8,7 @@ Kinesis Video Streams Signaling Service is a intermediate service that establish
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-kinesisvideosignaling` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/kms/README.md
+++ b/sdk/kms/README.md
@@ -37,7 +37,7 @@ Of the API operations discussed in this guide, the following will prove the most
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-kms` to
@@ -61,7 +61,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/lakeformation/README.md
+++ b/sdk/lakeformation/README.md
@@ -8,7 +8,7 @@ Defines the public endpoint for the AWS Lake Formation service.
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-lakeformation` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/lambda/README.md
+++ b/sdk/lambda/README.md
@@ -10,7 +10,7 @@ This is the _Lambda API Reference_. The Lambda Developer Guide provides addition
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-lambda` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/lexmodelbuilding/README.md
+++ b/sdk/lexmodelbuilding/README.md
@@ -8,7 +8,7 @@ Amazon Lex is an AWS service for building conversational voice and text interfac
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-lexmodelbuilding` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/lexmodelsv2/README.md
+++ b/sdk/lexmodelsv2/README.md
@@ -8,7 +8,7 @@ feedback purposes only. Do not use this SDK for production workloads.**
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-lexmodelsv2` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/lexruntime/README.md
+++ b/sdk/lexruntime/README.md
@@ -8,7 +8,7 @@ Amazon Lex provides both build and runtime endpoints. Each endpoint provides a s
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-lexruntime` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/lexruntimev2/README.md
+++ b/sdk/lexruntimev2/README.md
@@ -8,7 +8,7 @@ feedback purposes only. Do not use this SDK for production workloads.**
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-lexruntimev2` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/licensemanager/README.md
+++ b/sdk/licensemanager/README.md
@@ -8,7 +8,7 @@ License Manager makes it easier to manage licenses from software vendors across 
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-licensemanager` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/lightsail/README.md
+++ b/sdk/lightsail/README.md
@@ -12,7 +12,7 @@ This API Reference provides detailed information about the actions, data types, 
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-lightsail` to
@@ -36,7 +36,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/location/README.md
+++ b/sdk/location/README.md
@@ -8,7 +8,7 @@ Suite of geospatial services including Maps, Places, Routes, Tracking, and Geofe
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-location` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/lookoutequipment/README.md
+++ b/sdk/lookoutequipment/README.md
@@ -8,7 +8,7 @@ Amazon Lookout for Equipment is a machine learning service that uses advanced an
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-lookoutequipment` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/lookoutmetrics/README.md
+++ b/sdk/lookoutmetrics/README.md
@@ -8,7 +8,7 @@ This is the _Amazon Lookout for Metrics API Reference_. For an introduction to t
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-lookoutmetrics` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/lookoutvision/README.md
+++ b/sdk/lookoutvision/README.md
@@ -10,7 +10,7 @@ Amazon Lookout for Vision enables you to find visual defects in industrial produ
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-lookoutvision` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/machinelearning/README.md
+++ b/sdk/machinelearning/README.md
@@ -8,7 +8,7 @@ Definition of the public APIs exposed by Amazon Machine Learning
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-machinelearning` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/macie/README.md
+++ b/sdk/macie/README.md
@@ -8,7 +8,7 @@ Amazon Macie Classic is a security service that uses machine learning to automat
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-macie` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/macie2/README.md
+++ b/sdk/macie2/README.md
@@ -8,7 +8,7 @@ Amazon Macie is a fully managed data security and data privacy service that uses
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-macie2` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/managedblockchain/README.md
+++ b/sdk/managedblockchain/README.md
@@ -12,7 +12,7 @@ The description for each action indicates the framework or frameworks to which i
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-managedblockchain` to
@@ -36,7 +36,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/marketplacecatalog/README.md
+++ b/sdk/marketplacecatalog/README.md
@@ -10,7 +10,7 @@ You can automate your entity update process by integrating the AWS Marketplace C
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-marketplacecatalog` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/marketplacecommerceanalytics/README.md
+++ b/sdk/marketplacecommerceanalytics/README.md
@@ -8,7 +8,7 @@ Provides AWS Marketplace business intelligence data on-demand.
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-marketplacecommerceanalytics` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/marketplaceentitlement/README.md
+++ b/sdk/marketplaceentitlement/README.md
@@ -13,7 +13,7 @@ __Getting Entitlement Records__
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-marketplaceentitlement` to
@@ -37,7 +37,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/marketplacemetering/README.md
+++ b/sdk/marketplacemetering/README.md
@@ -24,7 +24,7 @@ BatchMeterUsage API calls are captured by AWS CloudTrail. You can use Cloudtrail
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-marketplacemetering` to
@@ -48,7 +48,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/mediaconnect/README.md
+++ b/sdk/mediaconnect/README.md
@@ -8,7 +8,7 @@ API for AWS Elemental MediaConnect
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-mediaconnect` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/mediaconvert/README.md
+++ b/sdk/mediaconvert/README.md
@@ -8,7 +8,7 @@ AWS Elemental MediaConvert
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-mediaconvert` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/medialive/README.md
+++ b/sdk/medialive/README.md
@@ -8,7 +8,7 @@ API for AWS Elemental MediaLive
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-medialive` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/mediapackage/README.md
+++ b/sdk/mediapackage/README.md
@@ -8,7 +8,7 @@ AWS Elemental MediaPackage
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-mediapackage` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/mediapackagevod/README.md
+++ b/sdk/mediapackagevod/README.md
@@ -8,7 +8,7 @@ AWS Elemental MediaPackage VOD
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-mediapackagevod` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/mediastore/README.md
+++ b/sdk/mediastore/README.md
@@ -8,7 +8,7 @@ An AWS Elemental MediaStore container is a namespace that holds folders and obje
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-mediastore` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/mediastoredata/README.md
+++ b/sdk/mediastoredata/README.md
@@ -8,7 +8,7 @@ An AWS Elemental MediaStore asset is an object, similar to an object in the Amaz
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-mediastoredata` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/mediatailor/README.md
+++ b/sdk/mediatailor/README.md
@@ -10,7 +10,7 @@ Through the SDKs and the CLI you manage AWS Elemental MediaTailor configurations
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-mediatailor` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/memorydb/README.md
+++ b/sdk/memorydb/README.md
@@ -8,7 +8,7 @@ MemoryDB for Redis is a fully managed, Redis-compatible, in-memory database that
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-memorydb` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/mgn/README.md
+++ b/sdk/mgn/README.md
@@ -8,7 +8,7 @@ The Application Migration Service service.
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-mgn` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/migrationhub/README.md
+++ b/sdk/migrationhub/README.md
@@ -10,7 +10,7 @@ Remember that you must set your AWS Migration Hub home region before you call an
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-migrationhub` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/migrationhubconfig/README.md
+++ b/sdk/migrationhubconfig/README.md
@@ -14,7 +14,7 @@ For specific API usage, see the sections that follow in this AWS Migration Hub H
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-migrationhubconfig` to
@@ -38,7 +38,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/mobile/README.md
+++ b/sdk/mobile/README.md
@@ -8,7 +8,7 @@ AWS Mobile Service provides mobile app and website developers with capabilities 
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-mobile` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/mq/README.md
+++ b/sdk/mq/README.md
@@ -8,7 +8,7 @@ Amazon MQ is a managed message broker service for Apache ActiveMQ and RabbitMQ t
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-mq` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/mturk/README.md
+++ b/sdk/mturk/README.md
@@ -8,7 +8,7 @@ feedback purposes only. Do not use this SDK for production workloads.**
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-mturk` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/mwaa/README.md
+++ b/sdk/mwaa/README.md
@@ -8,7 +8,7 @@ This section contains the Amazon Managed Workflows for Apache Airflow (MWAA) API
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-mwaa` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/neptune/README.md
+++ b/sdk/neptune/README.md
@@ -10,7 +10,7 @@ This interface reference for Amazon Neptune contains documentation for a program
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-neptune` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/networkfirewall/README.md
+++ b/sdk/networkfirewall/README.md
@@ -29,7 +29,7 @@ To start using Network Firewall, do the following:
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-networkfirewall` to
@@ -53,7 +53,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/networkmanager/README.md
+++ b/sdk/networkmanager/README.md
@@ -8,7 +8,7 @@ Transit Gateway Network Manager (Network Manager) enables you to create a global
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-networkmanager` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/nimble/README.md
+++ b/sdk/nimble/README.md
@@ -10,7 +10,7 @@ Nimble Studio is a virtual studio that empowers visual effects, animation, and i
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-nimble` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/opensearch/README.md
+++ b/sdk/opensearch/README.md
@@ -12,7 +12,7 @@ The endpoint for configuration service requests is region-specific: es._region_.
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-opensearch` to
@@ -36,7 +36,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/opsworks/README.md
+++ b/sdk/opsworks/README.md
@@ -44,7 +44,7 @@ When you call CreateStack, CloneStack, or UpdateStack we recommend you use the C
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-opsworks` to
@@ -68,7 +68,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/opsworkscm/README.md
+++ b/sdk/opsworkscm/README.md
@@ -34,7 +34,7 @@ All API operations allow for five requests per second with a burst of 10 request
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-opsworkscm` to
@@ -58,7 +58,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/organizations/README.md
+++ b/sdk/organizations/README.md
@@ -25,7 +25,7 @@ AWS Organizations supports AWS CloudTrail, a service that records AWS API calls 
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-organizations` to
@@ -49,7 +49,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/outposts/README.md
+++ b/sdk/outposts/README.md
@@ -8,7 +8,7 @@ AWS Outposts is a fully managed service that extends AWS infrastructure, APIs, a
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-outposts` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/panorama/README.md
+++ b/sdk/panorama/README.md
@@ -10,7 +10,7 @@ This is the _AWS Panorama API Reference_. For an introduction to the service, se
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-panorama` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/personalize/README.md
+++ b/sdk/personalize/README.md
@@ -8,7 +8,7 @@ Amazon Personalize is a machine learning service that makes it easy to add indiv
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-personalize` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/personalizeevents/README.md
+++ b/sdk/personalizeevents/README.md
@@ -8,7 +8,7 @@ Amazon Personalize can consume real-time user event data, such as _stream_ or _c
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-personalizeevents` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/personalizeruntime/README.md
+++ b/sdk/personalizeruntime/README.md
@@ -8,7 +8,7 @@ feedback purposes only. Do not use this SDK for production workloads.**
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-personalizeruntime` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/pi/README.md
+++ b/sdk/pi/README.md
@@ -14,7 +14,7 @@ DB load is measured as Average Active Sessions. Performance Insights provides th
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-pi` to
@@ -38,7 +38,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/pinpoint/README.md
+++ b/sdk/pinpoint/README.md
@@ -8,7 +8,7 @@ Doc Engage API - Amazon Pinpoint API
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-pinpoint` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/pinpointemail/README.md
+++ b/sdk/pinpointemail/README.md
@@ -16,7 +16,7 @@ In each Region, AWS maintains multiple Availability Zones. These Availability Zo
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-pinpointemail` to
@@ -40,7 +40,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/pinpointsmsvoice/README.md
+++ b/sdk/pinpointsmsvoice/README.md
@@ -8,7 +8,7 @@ Pinpoint SMS and Voice Messaging public facing APIs
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-pinpointsmsvoice` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/polly/README.md
+++ b/sdk/polly/README.md
@@ -10,7 +10,7 @@ The Amazon Polly service provides API operations for synthesizing high-quality s
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-polly` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/pricing/README.md
+++ b/sdk/pricing/README.md
@@ -16,7 +16,7 @@ Amazon Web Services Price List Service API provides the following two endpoints:
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-pricing` to
@@ -40,7 +40,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/proton/README.md
+++ b/sdk/proton/README.md
@@ -94,7 +94,7 @@ Asynchronous idempotent delete APIs:
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-proton` to
@@ -118,7 +118,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/qldb/README.md
+++ b/sdk/qldb/README.md
@@ -8,7 +8,7 @@ The control plane for Amazon QLDB
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-qldb` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/qldbsession/README.md
+++ b/sdk/qldbsession/README.md
@@ -8,7 +8,7 @@ The transactional data APIs for Amazon QLDB
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-qldbsession` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/quicksight/README.md
+++ b/sdk/quicksight/README.md
@@ -8,7 +8,7 @@ Amazon QuickSight is a fully managed, serverless business intelligence service f
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-quicksight` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/ram/README.md
+++ b/sdk/ram/README.md
@@ -12,7 +12,7 @@ To learn more about RAM, see the following resources:
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-ram` to
@@ -36,7 +36,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/rds/README.md
+++ b/sdk/rds/README.md
@@ -22,7 +22,7 @@ __Amazon RDS User Guide__
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-rds` to
@@ -46,7 +46,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/rdsdata/README.md
+++ b/sdk/rdsdata/README.md
@@ -10,7 +10,7 @@ For more information about the Data Service API, see [Using the Data API for Aur
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-rdsdata` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/redshift/README.md
+++ b/sdk/redshift/README.md
@@ -16,7 +16,7 @@ If you are a database developer, the [Amazon Redshift Database Developer Guide](
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-redshift` to
@@ -40,7 +40,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/redshiftdata/README.md
+++ b/sdk/redshiftdata/README.md
@@ -10,7 +10,7 @@ For more information about the Amazon Redshift Data API, see [Using the Amazon R
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-redshiftdata` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/rekognition/README.md
+++ b/sdk/rekognition/README.md
@@ -8,7 +8,7 @@ This is the Amazon Rekognition API reference.
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-rekognition` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/resourcegroups/README.md
+++ b/sdk/resourcegroups/README.md
@@ -19,7 +19,7 @@ AWS Resource Groups uses a REST-compliant API that you can use to perform the fo
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-resourcegroups` to
@@ -43,7 +43,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/resourcegroupstagging/README.md
+++ b/sdk/resourcegroupstagging/README.md
@@ -8,7 +8,7 @@ feedback purposes only. Do not use this SDK for production workloads.**
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-resourcegroupstagging` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/robomaker/README.md
+++ b/sdk/robomaker/README.md
@@ -8,7 +8,7 @@ This section provides documentation for the AWS RoboMaker API operations.
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-robomaker` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/route53/README.md
+++ b/sdk/route53/README.md
@@ -8,7 +8,7 @@ Amazon Route 53 is a highly available and scalable Domain Name System (DNS) web 
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-route53` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/route53domains/README.md
+++ b/sdk/route53domains/README.md
@@ -8,7 +8,7 @@ Amazon Route 53 API actions let you register domain names and perform related op
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-route53domains` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/route53recoverycluster/README.md
+++ b/sdk/route53recoverycluster/README.md
@@ -17,7 +17,7 @@ For more information about Route 53 Application Recovery Controller, see the fol
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-route53recoverycluster` to
@@ -41,7 +41,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/route53recoverycontrolconfig/README.md
+++ b/sdk/route53recoverycontrolconfig/README.md
@@ -8,7 +8,7 @@ Recovery Control Configuration API Reference for Amazon Route 53 Application Rec
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-route53recoverycontrolconfig` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/route53recoveryreadiness/README.md
+++ b/sdk/route53recoveryreadiness/README.md
@@ -8,7 +8,7 @@ AWS Route53 Recovery Readiness
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-route53recoveryreadiness` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/route53resolver/README.md
+++ b/sdk/route53resolver/README.md
@@ -20,7 +20,7 @@ Like Amazon VPC, Resolver is Regional. In each Region where you have VPCs, you c
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-route53resolver` to
@@ -44,7 +44,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/s3/README.md
+++ b/sdk/s3/README.md
@@ -8,7 +8,7 @@ feedback purposes only. Do not use this SDK for production workloads.**
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-s3` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/s3control/README.md
+++ b/sdk/s3control/README.md
@@ -8,7 +8,7 @@ Amazon Web Services S3 Control provides access to Amazon S3 control plane action
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-s3control` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/s3outposts/README.md
+++ b/sdk/s3outposts/README.md
@@ -8,7 +8,7 @@ Amazon S3 on Outposts provides access to S3 on Outposts operations.
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-s3outposts` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/sagemaker/README.md
+++ b/sdk/sagemaker/README.md
@@ -12,7 +12,7 @@ Other Resources:
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-sagemaker` to
@@ -36,7 +36,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/sagemakera2iruntime/README.md
+++ b/sdk/sagemakera2iruntime/README.md
@@ -16,7 +16,7 @@ Amazon A2I integrates APIs from various AWS services to create and start human r
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-sagemakera2iruntime` to
@@ -40,7 +40,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/sagemakeredge/README.md
+++ b/sdk/sagemakeredge/README.md
@@ -8,7 +8,7 @@ SageMaker Edge Manager dataplane service for communicating with active agents.
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-sagemakeredge` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/sagemakerfeaturestoreruntime/README.md
+++ b/sdk/sagemakerfeaturestoreruntime/README.md
@@ -14,7 +14,7 @@ Use the following operations to configure your OnlineStore and OfflineStore feat
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-sagemakerfeaturestoreruntime` to
@@ -38,7 +38,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/sagemakerruntime/README.md
+++ b/sdk/sagemakerruntime/README.md
@@ -8,7 +8,7 @@ The Amazon SageMaker runtime API.
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-sagemakerruntime` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/savingsplans/README.md
+++ b/sdk/savingsplans/README.md
@@ -8,7 +8,7 @@ Savings Plans are a pricing model that offer significant savings on AWS usage (f
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-savingsplans` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/schemas/README.md
+++ b/sdk/schemas/README.md
@@ -8,7 +8,7 @@ Amazon EventBridge Schema Registry
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-schemas` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/secretsmanager/README.md
+++ b/sdk/secretsmanager/README.md
@@ -30,7 +30,7 @@ Amazon Web Services Secrets Manager supports Amazon Web Services CloudTrail, a s
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-secretsmanager` to
@@ -54,7 +54,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/securityhub/README.md
+++ b/sdk/securityhub/README.md
@@ -19,7 +19,7 @@ The following throttling limits apply to using Security Hub API operations.
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-securityhub` to
@@ -43,7 +43,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/serverlessapplicationrepository/README.md
+++ b/sdk/serverlessapplicationrepository/README.md
@@ -15,7 +15,7 @@ The AWS Serverless Application Repository Developer Guide contains more informat
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-serverlessapplicationrepository` to
@@ -39,7 +39,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/servicecatalog/README.md
+++ b/sdk/servicecatalog/README.md
@@ -8,7 +8,7 @@ feedback purposes only. Do not use this SDK for production workloads.**
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-servicecatalog` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/servicecatalogappregistry/README.md
+++ b/sdk/servicecatalogappregistry/README.md
@@ -8,7 +8,7 @@ Amazon Web Services Service Catalog AppRegistry enables organizations to underst
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-servicecatalogappregistry` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/servicediscovery/README.md
+++ b/sdk/servicediscovery/README.md
@@ -8,7 +8,7 @@ With Cloud Map, you can configure public DNS, private DNS, or HTTP namespaces th
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-servicediscovery` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/servicequotas/README.md
+++ b/sdk/servicequotas/README.md
@@ -8,7 +8,7 @@ With Service Quotas, you can view and manage your quotas easily as your AWS work
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-servicequotas` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/ses/README.md
+++ b/sdk/ses/README.md
@@ -8,7 +8,7 @@ This document contains reference information for the [Amazon Simple Email Servic
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-ses` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/sesv2/README.md
+++ b/sdk/sesv2/README.md
@@ -10,7 +10,7 @@ If you're new to Amazon SES API v2, you might find it helpful to review the [Ama
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-sesv2` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/sfn/README.md
+++ b/sdk/sfn/README.md
@@ -12,7 +12,7 @@ Step Functions manages operations and underlying infrastructure to ensure your a
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-sfn` to
@@ -36,7 +36,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/shield/README.md
+++ b/sdk/shield/README.md
@@ -8,7 +8,7 @@ This is the _Shield Advanced API Reference_. This guide is for developers who ne
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-shield` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/signer/README.md
+++ b/sdk/signer/README.md
@@ -16,7 +16,7 @@ For more information about AWS Signer, see the [AWS Signer Developer Guide](http
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-signer` to
@@ -40,7 +40,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/sms/README.md
+++ b/sdk/sms/README.md
@@ -10,7 +10,7 @@ AWS Server Migration Service (AWS SMS) makes it easier and faster for you to mig
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-sms` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/snowball/README.md
+++ b/sdk/snowball/README.md
@@ -8,7 +8,7 @@ AWS Snow Family is a petabyte-scale data transport solution that uses secure dev
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-snowball` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/snowdevicemanagement/README.md
+++ b/sdk/snowdevicemanagement/README.md
@@ -8,7 +8,7 @@ Amazon Web Services Snow Device Management documentation.
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-snowdevicemanagement` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/sns/README.md
+++ b/sdk/sns/README.md
@@ -12,7 +12,7 @@ We also provide SDKs that enable you to access Amazon SNS from your preferred pr
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-sns` to
@@ -36,7 +36,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/sqs/README.md
+++ b/sdk/sqs/README.md
@@ -28,7 +28,7 @@ __Additional information__
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-sqs` to
@@ -52,7 +52,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/ssm/README.md
+++ b/sdk/ssm/README.md
@@ -18,7 +18,7 @@ __Related resources__
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-ssm` to
@@ -42,7 +42,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/ssmcontacts/README.md
+++ b/sdk/ssmcontacts/README.md
@@ -10,7 +10,7 @@ Incident Manager increases incident resolution by notifying responders of impact
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-ssmcontacts` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/ssmincidents/README.md
+++ b/sdk/ssmincidents/README.md
@@ -10,7 +10,7 @@ Incident Manager increases incident resolution by notifying responders of impact
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-ssmincidents` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/sso/README.md
+++ b/sdk/sso/README.md
@@ -12,7 +12,7 @@ This API reference guide describes the AWS SSO Portal operations that you can ca
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-sso` to
@@ -36,7 +36,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/ssoadmin/README.md
+++ b/sdk/ssoadmin/README.md
@@ -10,7 +10,7 @@ Many operations in the SSO APIs rely on identifiers for users and groups, known 
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-ssoadmin` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/ssooidc/README.md
+++ b/sdk/ssooidc/README.md
@@ -12,7 +12,7 @@ This API reference guide describes the AWS SSO OIDC operations that you can call
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-ssooidc` to
@@ -36,7 +36,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/storagegateway/README.md
+++ b/sdk/storagegateway/README.md
@@ -25,7 +25,7 @@ For more information, see [Announcement: Heads-up – Longer Storage Gateway vol
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-storagegateway` to
@@ -49,7 +49,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/sts/README.md
+++ b/sdk/sts/README.md
@@ -8,7 +8,7 @@ Security Token Service (STS) enables you to request temporary, limited-privilege
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-sts` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/support/README.md
+++ b/sdk/support/README.md
@@ -26,7 +26,7 @@ See [About the AWS Support API](https://docs.aws.amazon.com/awssupport/latest/us
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-support` to
@@ -50,7 +50,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/swf/README.md
+++ b/sdk/swf/README.md
@@ -12,7 +12,7 @@ This documentation serves as reference only. For a broader overview of the Amazo
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-swf` to
@@ -36,7 +36,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/synthetics/README.md
+++ b/sdk/synthetics/README.md
@@ -10,7 +10,7 @@ Before you create and manage canaries, be aware of the security considerations. 
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-synthetics` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/textract/README.md
+++ b/sdk/textract/README.md
@@ -8,7 +8,7 @@ Amazon Textract detects and analyzes text in documents and converts it into mach
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-textract` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/transcribe/README.md
+++ b/sdk/transcribe/README.md
@@ -8,7 +8,7 @@ Operations and objects for transcribing speech to text.
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-transcribe` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/transcribestreaming/README.md
+++ b/sdk/transcribestreaming/README.md
@@ -8,7 +8,7 @@ Operations and objects for transcribing streaming speech to text.
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-transcribestreaming` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/transfer/README.md
+++ b/sdk/transfer/README.md
@@ -8,7 +8,7 @@ Amazon Web Services Transfer Family is a fully managed service that enables the 
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-transfer` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/translate/README.md
+++ b/sdk/translate/README.md
@@ -8,7 +8,7 @@ Provides translation between one source language and another of the same set of 
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-translate` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/voiceid/README.md
+++ b/sdk/voiceid/README.md
@@ -8,7 +8,7 @@ Amazon Connect Voice ID provides real-time caller authentication and fraud scree
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-voiceid` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/waf/README.md
+++ b/sdk/waf/README.md
@@ -8,7 +8,7 @@ This is the _AWS WAF Classic API Reference_ for using AWS WAF Classic with Amazo
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-waf` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/wafregional/README.md
+++ b/sdk/wafregional/README.md
@@ -8,7 +8,7 @@ This is the _AWS WAF Regional Classic API Reference_ for using AWS WAF Classic w
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-wafregional` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/wafv2/README.md
+++ b/sdk/wafv2/README.md
@@ -21,7 +21,7 @@ We currently provide two versions of the WAF API: this API and the prior version
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-wafv2` to
@@ -45,7 +45,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/wellarchitected/README.md
+++ b/sdk/wellarchitected/README.md
@@ -8,7 +8,7 @@ This is the _AWS Well-Architected Tool API Reference_. The AWS Well-Architected 
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-wellarchitected` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/wisdom/README.md
+++ b/sdk/wisdom/README.md
@@ -10,7 +10,7 @@ Some more advanced features are only accessible using the Wisdom API. For exampl
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-wisdom` to
@@ -34,7 +34,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/workdocs/README.md
+++ b/sdk/workdocs/README.md
@@ -13,7 +13,7 @@ All Amazon WorkDocs API actions are Amazon authenticated and certificate-signed.
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-workdocs` to
@@ -37,7 +37,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/worklink/README.md
+++ b/sdk/worklink/README.md
@@ -8,7 +8,7 @@ Amazon WorkLink is a cloud-based service that provides secure access to internal
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-worklink` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/workmail/README.md
+++ b/sdk/workmail/README.md
@@ -16,7 +16,7 @@ All WorkMail API operations are Amazon-authenticated and certificate-signed. The
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-workmail` to
@@ -40,7 +40,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/workmailmessageflow/README.md
+++ b/sdk/workmailmessageflow/README.md
@@ -8,7 +8,7 @@ The WorkMail Message Flow API provides access to email messages as they are bein
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-workmailmessageflow` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/workspaces/README.md
+++ b/sdk/workspaces/README.md
@@ -8,7 +8,7 @@ Amazon WorkSpaces enables you to provision virtual, cloud-based Microsoft Window
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-workspaces` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 

--- a/sdk/xray/README.md
+++ b/sdk/xray/README.md
@@ -8,7 +8,7 @@ Amazon Web Services X-Ray provides APIs for managing debug traces and retrieving
 ## Getting Started
 
 > Examples are available for many services and operations, check out the
-> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+> [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
 The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
 as a dependency within your Rust project to execute asynchronous code. To add `aws-sdk-xray` to
@@ -32,7 +32,7 @@ additional sections for the guide by opening an issue and describing what you ar
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
 ## License
 


### PR DESCRIPTION
READMEs point to https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples which is a dead link.
The links are visible on crates.io.

This PR fixes the links.