### PR TITLE
Fix RUST_LOG module name in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -65,11 +65,11 @@ if you haven't already (e.g., `tracing_subscriber::fmt::init();`),
 and then setting the environment variable `RUST_LOG` before
 running your program, as follows:
 
-`RUST_LOG='smithy_http_tower::dispatch=trace,smithy_http::middleware=trace'`
+`RUST_LOG='aws_smithy_http_tower::dispatch=trace,aws_smithy_http::middleware=trace'`
 
 For example:
 
-`RUST_LOG='smithy_http_tower::dispatch=trace,smithy_http::middleware=trace' cargo run`
+`RUST_LOG='aws_smithy_http_tower::dispatch=trace,aws_smithy_http::middleware=trace' cargo run`
 
 The SDK redacts sensitive information such as auth headers in these trace logs,
 but please look through them before posting just to be sure.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The module names are renamed in v0.0.22-alpha.
https://github.com/awslabs/aws-sdk-rust/blob/main/CHANGELOG.md#v0022-alpha-october-20th-2021

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
