### PR TITLE
Emit CloudWatch metrics from the canary runner

### DIFF
--- a/tools/ci/canary-runner/Cargo.toml
+++ b/tools/ci/canary-runner/Cargo.toml
@@ -12,6 +12,7 @@ publish = false
 [dependencies]
 anyhow = "1"
 aws-config = "0.3"
+aws-sdk-cloudwatch = "0.3"
 aws-sdk-lambda = "0.3"
 aws-sdk-s3 = "0.3"
 base64 = "0.13"


### PR DESCRIPTION
This PR adds success, failure, and timing metrics to the canary runner.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
