### PR TITLE
add Step Functions examples

### DIFF
--- a/examples/stepfunction/Cargo.toml
+++ b/examples/stepfunction/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "step-function-code-examples"
+version = "0.1.0"
+
+[dependencies.aws-config]
+path = "../../sdk/aws-config"
+version = "0.4.1"
+
+[dependencies.aws-sdk-sfn]
+path = "../../sdk/sfn"
+version = "0.4.1"
+
+[dependencies.tokio]
+version = "1"
+features = ["full"]
+
+[dependencies.tracing-subscriber]
+version = "0.3.5"
+features = ["env-filter"]

--- a/examples/stepfunction/src/bin/start-execution.rs
+++ b/examples/stepfunction/src/bin/start-execution.rs
@@ -1,0 +1,49 @@
+use aws_sdk_sfn::{Client, Error};
+use std::process::exit;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+struct Opt {
+    /// The Amazon Resource Name (ARN) of the state machine to execute.
+    #[structopt(short, long)]
+    arn: Option<String>,
+
+    /// The string that contains the JSON input data for the execution, for example "{\"first_name\" : \"test\"}".
+    #[structopt(short, long)]
+    input: String,
+}
+
+/// Starts a state machine execution.
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::fmt::init();
+
+    let Opt {
+        arn,
+        input,
+    } = Opt::from_args();
+
+    let shared_config = aws_config::load_from_env().await;
+    let client = Client::new(&shared_config);
+
+    println!();
+
+    if verbose {
+        println!("SF arn: {}", &arn);
+        println!("Input:  {}", &input);
+        println!();
+    }
+    
+    let rsp = client
+        .start_execution()
+        .state_machine_arn(Some(&arn))
+        .send()
+        .await?;
+
+    println!(
+        "Step function response: `{:?}`",
+        rsp
+    );
+
+    Ok(())
+}

--- a/examples/stepfunction/src/bin/stop-execution.rs
+++ b/examples/stepfunction/src/bin/stop-execution.rs
@@ -1,0 +1,44 @@
+use aws_sdk_sfn::{Client, Error};
+use std::process::exit;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+struct Opt {
+    /// The Amazon Resource Name (ARN) of the state machine to execute.
+    #[structopt(short, long)]
+    arn: Option<String>,
+}
+
+/// Starts a state machine execution.
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::fmt::init();
+
+    let Opt {
+        arn,
+        input,
+    } = Opt::from_args();
+
+    let shared_config = aws_config::load_from_env().await;
+    let client = Client::new(&shared_config);
+
+    println!();
+
+    if verbose {
+        println!("SF arn: {}", &arn);
+        println!();
+    }
+    
+    let rsp = client
+        .stop_execution()
+        .execution_arn(&arn)
+        .send()
+        .await?;
+
+    println!(
+        "Step function response: `{:?}`",
+        rsp
+    );
+
+    Ok(())
+}

--- a/index.md
+++ b/index.md
@@ -260,6 +260,7 @@ The AWS SDK for Rust contains one crate for each AWS service, as well as [aws-co
 | Amazon Simple Queue Service | [aws-sdk-sqs](https://crates.io/crates/aws-sdk-sqs) ([docs](https://docs.rs/aws-sdk-sqs)) ([examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples/sqs)) |
 | Amazon Simple Storage Service | [aws-sdk-s3](https://crates.io/crates/aws-sdk-s3) ([docs](https://docs.rs/aws-sdk-s3)) ([examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples/s3)) |
 | Amazon Simple Systems Manager (SSM) | [aws-sdk-ssm](https://crates.io/crates/aws-sdk-ssm) ([docs](https://docs.rs/aws-sdk-ssm)) ([examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples/ssm)) |
+| Amazon Step Functions | [aws-sdk-sfn](https://crates.io/crates/aws-sdk-sfn) ([docs](https://docs.rs/aws-sdk-sfn)) ([examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples/stepfunction)) |
 | Amazon Simple Workflow Service | [aws-sdk-swf](https://crates.io/crates/aws-sdk-swf) ([docs](https://docs.rs/aws-sdk-swf)) |
 | Amazon Textract | [aws-sdk-textract](https://crates.io/crates/aws-sdk-textract) ([docs](https://docs.rs/aws-sdk-textract)) |
 | Amazon Transcribe Service | [aws-sdk-transcribe](https://crates.io/crates/aws-sdk-transcribe) ([docs](https://docs.rs/aws-sdk-transcribe)) |


### PR DESCRIPTION
*Description of changes:*
I added two examples for AWS Step Functions:

1. startExecution
2. stopExecution


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution under the terms of your choice.
