### PR TITLE
Make psuedo job fail if dependency jobs failed in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,11 +63,15 @@ jobs:
   # the myriad of test range combinations into GitHub's protected branch rules
   require-tests:
     needs: test
+    # Run this job even if its dependency jobs fail
+    if: always()
     runs-on: ubuntu-latest
     name: Test Matrix Success
     steps:
-      - name: Run
-        run: echo "We should only get this far if the test matrix succeeded."
+      - name: Verify jobs succeeded
+        uses: re-actors/alls-green@3a2de129f0713010a71314c74e33c0e3ef90e696
+        with:
+          jobs: ${{ toJSON(needs) }}
 
   check-manifests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The psuedo jobs are getting skipped when the jobs they depend on fail, and that's allowing merge with failing tests. This makes the psuedo jobs always run and check the status of the jobs they depend on.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
