### PR TITLE
Remove README and CHANGELOG from handwritten files list

### DIFF
--- a/.handwritten
+++ b/.handwritten
@@ -18,10 +18,8 @@
 /_config.yml
 /.gitignore
 /.handwritten
-/CHANGELOG.md
 /CODE_OF_CONDUCT.md
 /CODEOWNERS
 /CONTRIBUTING.md
 /LICENSE
 /NOTICE
-/README.md


### PR DESCRIPTION
This change is needed for https://github.com/awslabs/smithy-rs/pull/1109 to work properly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
