### PR TITLE
Force push `next` when syncing so that it can be rebased

### DIFF
--- a/.github/workflows/smithy-rs-sync.yml
+++ b/.github/workflows/smithy-rs-sync.yml
@@ -51,4 +51,4 @@ jobs:
       run: |
         git config --global user.name "AWS SDK Rust Bot"
         git config --global user.email "aws-sdk-rust-primary@amazon.com"
-        git push
+        git push --force


### PR DESCRIPTION
This change is required for https://github.com/awslabs/smithy-rs/pull/1115 to work.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
