### PR TITLE
Fix canary generate matrix step

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -12,17 +12,21 @@ jobs:
     name: Generate Canary Matrix
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+        with:
+          repository: awslabs/smithy-rs
+          path: smithy-rs
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ env.tool_rust_version }}
           default: true
       - name: Generate the matrix
         id: generate-matrix
+        working-directory: smithy-rs/tools/ci-cdk/canary-runner
         # Run the `canary-runner generate-matrix` subcommand to calculate a test matrix
         # for the `canary` job. This script outputs JSON that GitHub Actions can consume
         # as a matrix definition. Rust versions to test against are arguments to this script.
         run: |
-          cd tools/ci/canary-runner
           cargo build
           echo "::set-output name=matrix::$(cargo run -- generate-matrix --sdk-versions 3 --rust-versions 1.54.0 1.56.1)"
     outputs:


### PR DESCRIPTION
This fixes the generate matrix step of the canary GitHub Actions workflow. [This test run](https://github.com/awslabs/aws-sdk-rust/runs/5045538762) shows this step succeeding after these changes. ~~There's still work that needs to be done to fix the canary-runner against the version of Rust being used in CI, but that will be done separately in smithy-rs where the runner lives.~~ The canary-runner has been fixed in https://github.com/awslabs/smithy-rs/pull/1155.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
