### PR TITLE
Readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The SDK currently requires a minimum of Rust 1.58.1, and is not guaranteed to bu
 
 - Design docs - Design documentation for the SDK lives in the [design folder of smithy-rs](https://github.com/awslabs/smithy-rs/tree/main/design).
 - Runtime / Handwritten code: The Rust Runtime code that underpins the SDK can be accessed [here](https://github.com/awslabs/smithy-rs/tree/main/rust-runtime) and [here](https://github.com/awslabs/smithy-rs/tree/main/aws/rust-runtime). This code is copied into this repo as part of code generation.
-- [Code Examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
+- [Code Examples](./examples)
 - [API reference documentation (rustdoc)](https://awslabs.github.io/aws-sdk-rust/)
 
 ## Security

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ While we're working on the SDK, detailed usage instructions will be added to the
 * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
 * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
 * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-* [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
+* [Usage examples](./examples)
 
 ## Feedback and Contributing
 


### PR DESCRIPTION
<!--

IMPORTANT:

> Making changes to examples? 

no


> Making changes to code?

no

-->


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here -->

Example links in Readme is hard coded. This pr changes it to link to the internal examples directory so that you can see the examples for the current branch checkout out. This also makes it easier to browse when pushed to other git sites like gitea. 
