### PR TITLE
Add `aws-models/` to handwritten files list

### DIFF
--- a/.handwritten
+++ b/.handwritten
@@ -12,6 +12,7 @@
 /.github/
 /.git/
 /tools/
+/aws-models/
 
 # Files
 


### PR DESCRIPTION
## Motivation and Context
Without this change, the next release will clear out the models directory.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
