### PR TITLE
Add missing entry to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ v0.14.0 (June 22nd, 2022)
 - 🐛 ([aws-sdk-rust#558](https://github.com/awslabs/aws-sdk-rust/issues/558), [smithy-rs#1478](https://github.com/awslabs/smithy-rs/issues/1478)) Fix bug in retry policy where user configured timeouts were not retried. With this fix, setting
     [`with_call_attempt_timeout`](https://docs.rs/aws-smithy-types/0.43.0/aws_smithy_types/timeout/struct.Api.html#method.with_call_attempt_timeout)
     will lead to a retry when retries are enabled.
+- 🐛 ([aws-sdk-rust#554](https://github.com/awslabs/aws-sdk-rust/issues/554)) Requests to Route53 that return `ResourceId`s often come with a prefix. When passing those IDs directly into another
+    request, the request would fail unless they manually stripped the prefix. Now, when making a request with a prefixed ID,
+    the prefix will be stripped automatically.
 
 
 v0.13.0 (June 9th, 2022)


### PR DESCRIPTION
## Motivation and Context
This changelog entry was unintentionally added to smithy-rs rather than to aws-sdk-rust.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
