### PR TITLE
Add `CHANGELOG.md` to handwritten files

### DIFF
--- a/.handwritten
+++ b/.handwritten
@@ -19,8 +19,9 @@
 /_config.yml
 /.gitignore
 /.handwritten
-/CODE_OF_CONDUCT.md
+/CHANGELOG.md
 /CODEOWNERS
+/CODE_OF_CONDUCT.md
 /CONTRIBUTING.md
 /LICENSE
 /NOTICE


### PR DESCRIPTION
## Motivation and Context
The automated release process while aws-sdk-rust release was coupled to smithy-rs release had the source of truth for the SDK changelog stored in smithy-rs. Thus, it was safe then for the `sdk-sync` tool to delete aws-sdk-rust's `CHANGELOG.md` before copying generated code across.

With the releases decoupled, the `CHANGELOG.md` in aws-sdk-rust becomes the source of truth, so `sdk-sync` should NOT delete it prior to syncing anymore.

Given how `sdk-sync` is written (to do a `cp -r`), this change should be safe for both the coupled and decoupled release process. The coupled release process will overwrite it with the generated copy from smithy-rs, and the decoupled process will preserve it and prepend new entries to it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
