### PR TITLE
Update Canary Rust Versions

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -4,7 +4,7 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 env:
-  tool_rust_version: 1.56.1
+  tool_rust_version: 1.58.1
 
 jobs:
   generate-canary-matrix:
@@ -28,7 +28,7 @@ jobs:
         # as a matrix definition. Rust versions to test against are arguments to this script.
         run: |
           cargo build
-          echo "::set-output name=matrix::$(cargo run -- generate-matrix --sdk-versions 3 --rust-versions 1.56.1 1.58.1)"
+          echo "::set-output name=matrix::$(cargo run -- generate-matrix --sdk-versions 3 --rust-versions 1.58.1 1.59.0 1.60.0 1.61.0)"
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
 


### PR DESCRIPTION
<!--

IMPORTANT:

> Making changes to examples? 

Be sure to make example changes in the awsdocs/aws-doc-sdk-examples repository (https://github.com/awsdocs/aws-doc-sdk-examples).
The examples in aws-sdk-rust are copied from the `rust_dev_preview/` directory in that repository.


> Making changes to code?

All the code in aws-sdk-rust is auto-generated by smithy-rs (https://github.com/awslabs/smithy-rs).
Changes to code need to be made in that repository.

-->


## Motivation and Context
- time does not compile on 1.56.1 anymore and neither does the Rust SDK—fix the canary

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
