### PR TITLE
issue template: `cargo tree` ships with cargo now

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -66,9 +66,6 @@ body:
       render: text
       description: |
         List the versions & crates of the aws-rust-sdk you are using.
-        `cargo install cargo-tree`
-        (see install here: https://github.com/sfackler/cargo-tree)
-        Then:
         `cargo tree | grep aws-`
     validations:
       required: true


### PR DESCRIPTION
## Motivation and Context

`cargo tree` ships with `cargo` now; avoid recommending installation of the external one (which is deprecated in favor of the integrated one).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
