### PR TITLE
`aws-config`: Fix compilation error with `rustls` and `native-tls` disabled

### DIFF
--- a/sdk/aws-config/Cargo.toml
+++ b/sdk/aws-config/Cargo.toml
@@ -14,10 +14,11 @@ targets = ["x86_64-unknown-linux-gnu"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
+client-hyper = ["aws-smithy-client/client-hyper"]
 rustls = ["aws-smithy-client/rustls"]
 native-tls = ["aws-smithy-client/native-tls"]
 rt-tokio = ["aws-smithy-async/rt-tokio"]
-default = ["rustls", "rt-tokio"]
+default = ["client-hyper", "rustls", "rt-tokio"]
 
 [dependencies]
 ring = "0.16"
@@ -43,6 +44,7 @@ version = "0.45.0"
 [dependencies.aws-smithy-client]
 path = "../aws-smithy-client"
 version = "0.45.0"
+default-features = false
 
 [dependencies.aws-smithy-types]
 path = "../aws-smithy-types"

--- a/sdk/aws-config/src/provider_config.rs
+++ b/sdk/aws-config/src/provider_config.rs
@@ -239,6 +239,7 @@ impl ProviderConfig {
     ///
     /// # Stability
     /// This method may change to support HTTP configuration.
+    #[cfg(feature = "client-hyper")]
     pub fn with_tcp_connector<C>(self, connector: C) -> Self
     where
         C: Clone + Send + Sync + 'static,


### PR DESCRIPTION
The `ProviderConfig::with_tcp_connector` method uses
`aws_smithy_client::hyper_ext`, which only exists with the
`client-hyper` feature enabled. Add a feature enabling that, and enable
it by default.

Introducing this feature does not cause breakage, because aws-config
did not previously compile with `default-features = false` and neither
`rustls` nor `native-tls` enabled.

## Motivation and Context

Without this change:
```
error[E0433]: failed to resolve: could not find `hyper_ext` in `aws_smithy_client`
   --> /home/josh/.cargo/registry/src/github.com-1ecc6299db9ec823/aws-config-0.15.0/src/provider_config.rs:251:50
    |
251 |             let mut builder = aws_smithy_client::hyper_ext::Adapter::builder()
    |                                                  ^^^^^^^^^ could not find `hyper_ext` in `aws_smithy_client`
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
