### PR TITLE
Extend ancient issue auto-closing

### DIFF
--- a/.github/workflows/stale_issue.yaml
+++ b/.github/workflows/stale_issue.yaml
@@ -32,7 +32,8 @@ jobs:
         # Issue timing
         days-before-stale: 7
         days-before-close: 4
-        days-before-ancient: 365
+        # TODO: Change back to 365 once the SDK is GA
+        days-before-ancient: 10000
 
         # If you don't want to mark a issue as being ancient based on a
         # threshold of "upvotes", you can set this here. An "upvote" is


### PR DESCRIPTION
## Motivation and Context
At this point in development, our ancient issues are important to us since they represent our backlog of things to implement for the SDK. This PR extends the ancient issue time so that the bot won't auto-close anything important to us any time soon.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
