### PR TITLE
Fix Redshift Serverless model

### DIFF
--- a/aws-models/redshift-serverless.json
+++ b/aws-models/redshift-serverless.json
@@ -2558,7 +2558,7 @@
             "type": "service",
             "traits": {
                 "aws.api#service": {
-                    "sdkId": "RedshiftServerless",
+                    "sdkId": "Redshift Serverless",
                     "arnNamespace": "redshift-serverless"
                 },
                 "aws.auth#sigv4": {
@@ -2572,7 +2572,7 @@
                 ],
                 "aws.protocols#awsJson1_1": {},
                 "smithy.api#cors": {},
-                "smithy.api#documentation": "<p>\n            <i>This is prerelease documentation for Amazon Redshift Serverless, which is in preview release. \n           The documentation and the feature are both subject to change. We recommend that you use this feature only in test environments, \n           and not in production environments. For preview terms and conditions, see Beta Service Participation in \n           <a href=\"https://docs.aws.amazon.com/https:/aws.amazon.com/service-terms\">Amazon Web Services Service Terms</a>.</i>\n         </p>\n        <p>This is an interface reference for Amazon Redshift Serverless. \n           It contains documentation for one of the programming or command line interfaces you can use to manage Amazon Redshift Serverless.\n        </p>\n        <p>Amazon Redshift Serverless automatically provisions data warehouse capacity and intelligently scales the \n           underlying resources based on workload demands. Amazon Redshift Serverless adjusts capacity in seconds to deliver consistently high \n           performance and simplified operations for even the most demanding and volatile workloads. Amazon Redshift Serverless lets you\n           focus on using your data to acquire new insights for your business and customers.\n        </p>\n        <p>\n           To learn more about Amazon Redshift Serverless, \n           see <a href=\"https://docs.aws.amazon.com/redshift/latest/mgmt/serverless-whatis.html\">What is Amazon Redshift Serverless</a>.\n        </p>",
+                "smithy.api#documentation": "<p>This is an interface reference for Amazon Redshift Serverless. \n           It contains documentation for one of the programming or command line interfaces you can use to manage Amazon Redshift Serverless.\n        </p>\n        <p>Amazon Redshift Serverless automatically provisions data warehouse capacity and intelligently scales the \n           underlying resources based on workload demands. Amazon Redshift Serverless adjusts capacity in seconds to deliver consistently high \n           performance and simplified operations for even the most demanding and volatile workloads. Amazon Redshift Serverless lets you\n           focus on using your data to acquire new insights for your business and customers.\n        </p>\n        <p>\n           To learn more about Amazon Redshift Serverless, \n           see <a href=\"https://docs.aws.amazon.com/redshift/latest/mgmt/serverless-whatis.html\">What is Amazon Redshift Serverless</a>.\n        </p>",
                 "smithy.api#title": "Redshift Serverless"
             },
             "version": "2021-04-21",

--- a/versions.toml
+++ b/versions.toml
@@ -1,5 +1,9 @@
 smithy_rs_revision = '700cee65ca1695cedff04ea7aca0d60b8654433d'
 aws_doc_sdk_examples_revision = '00b3c7344ae0ff27dd0e515e5c36e4331c5cefa9'
+
+[manual_interventions]
+crates_to_remove = ['aws-sdk-redshiftserverless']
+
 [crates.aws-config]
 category = 'AwsRuntime'
 version = '0.46.0'


### PR DESCRIPTION
## Motivation and Context
Redshift Serverless was originally released with the wrong `sdkId`, and this incorrect model was pulled into aws-sdk-rust before it was reverted/fixed. This PR corrects the model by deleting the incorrect `redshiftserverless` model and using the `sync-models.py` script to pull in the correct `redshift-serverless` model. It also marks the old model's crate name as removed to prevent the next release failing due to a previously published SDK crate being absent from the list of crates to publish.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
