### PR TITLE
Fix the SDK canary

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -39,7 +39,7 @@ jobs:
     env:
       AWS_DEFAULT_REGION: us-west-2
       CARGO_INCREMENTAL: "0"
-      SDK_VERSION: ${{ matrix.sdk_version }}
+      SDK_RELEASE_TAG: ${{ matrix.sdk_release_tag }}
       LAMBDA_CODE_S3_BUCKET_NAME: ${{ secrets.CANARY_LAMBDA_CODE_S3_BUCKET }}
       LAMBDA_TEST_S3_BUCKET_NAME: ${{ secrets.CANARY_LAMBDA_TEST_S3_BUCKET }}
       LAMBDA_EXECUTION_ROLE_ARN: ${{ secrets.CANARY_LAMBDA_EXECUTION_ROLE_ARN }}
@@ -79,7 +79,7 @@ jobs:
         working-directory: smithy-rs/tools/ci-cdk/canary-runner
         run: |
           cargo run -- \
-            run --sdk-version ${SDK_VERSION} \
+            run --sdk-release-tag ${SDK_RELEASE_TAG} \
                 --lambda-code-s3-bucket-name ${LAMBDA_CODE_S3_BUCKET_NAME} \
                 --lambda-test-s3-bucket-name ${LAMBDA_TEST_S3_BUCKET_NAME} \
                 --lambda-execution-role-arn ${LAMBDA_EXECUTION_ROLE_ARN}


### PR DESCRIPTION
## Motivation and Context
This PR fixes #594 and requires the changes in https://github.com/awslabs/smithy-rs/pull/1588. This changes the canary workflow to operate on release tags instead of version numbers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
