### PR TITLE
Update audit workflow to also check minimal versions

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ env.rust_version }}
+          default: true
       - name: install cargo audit
         run: cargo install cargo-audit
       - name: Run audit

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
   pull_request:
 env:
-  rust_version: 1.56.1
+  rust_version: nightly-2022-07-25
 
 jobs:
   audit:
@@ -18,23 +18,32 @@ jobs:
       - name: install cargo audit
         run: cargo install cargo-audit
       - name: Run audit
-        # RUSTSEC-2020-0071 , RUSTSEC-2020-0159
-        # chrono, a Rust date-time crate we use for timestamp parsing was added
-        # to the RustSec vulnerability database because of a call to localtime_r.
-        # We use chrono for an extremely narrow use case of converting epoch timestamps to UTC dates
-        # (so we never invoke the problematic behavior that results from attempting to determine
-        # the local time of the current platform).
-        #
-        # Chrono's only use is as an optional feature in `aws-smithy-types-convert`, for
-        # the narrow use-case of converting from the SDK's `DateTime` into chrono types,
-        # and we never invoke the problematic behavior that results from attempting to
-        # determine the local time of the current platform.
-        #
-        # RUSTSEC-2021-0127
-        # serde_cbor is being imported by criterion, a benchmarking crate. More info here https://github.com/awslabs/smithy-rs/issues/1044
         run: |
-          cargo audit \
+          set -eux
+
+          # RUSTSEC-2020-0071 , RUSTSEC-2020-0159
+          # chrono, a Rust date-time crate we use for timestamp parsing was added
+          # to the RustSec vulnerability database because of a call to localtime_r.
+          # We use chrono for an extremely narrow use case of converting epoch timestamps to UTC dates
+          # (so we never invoke the problematic behavior that results from attempting to determine
+          # the local time of the current platform).
+          #
+          # Chrono's only use is as an optional feature in `aws-smithy-types-convert`, for
+          # the narrow use-case of converting from the SDK's `DateTime` into chrono types,
+          # and we never invoke the problematic behavior that results from attempting to
+          # determine the local time of the current platform.
+          #
+          # RUSTSEC-2021-0127
+          # serde_cbor is being imported by criterion, a benchmarking crate. More info here https://github.com/awslabs/smithy-rs/issues/1044
+          CARGO_AUDIT_FLAGS="\
             --ignore RUSTSEC-2020-0071 \
             --ignore RUSTSEC-2020-0159 \
-            --ignore RUSTSEC-2021-0127
+            --ignore RUSTSEC-2021-0127 \
+          "
 
+          echo "Auditing the latest dependencies"
+          cargo audit ${CARGO_AUDIT_FLAGS}
+
+          echo "Downgrading dependencies to minimal versions and auditing"
+          cargo update -Zminimal-versions
+          cargo audit ${CARGO_AUDIT_FLAGS}

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -7,8 +7,25 @@ on:
 env:
   rust_version: nightly-2022-07-25
 
+  # RUSTSEC-2020-0071 , RUSTSEC-2020-0159
+  # chrono, a Rust date-time crate we use for timestamp parsing was added
+  # to the RustSec vulnerability database because of a call to localtime_r.
+  # We use chrono for an extremely narrow use case of converting epoch timestamps to UTC dates
+  # (so we never invoke the problematic behavior that results from attempting to determine
+  # the local time of the current platform).
+  #
+  # Chrono's only use is as an optional feature in `aws-smithy-types-convert`, for
+  # the narrow use-case of converting from the SDK's `DateTime` into chrono types,
+  # and we never invoke the problematic behavior that results from attempting to
+  # determine the local time of the current platform.
+  #
+  # RUSTSEC-2021-0127
+  # serde_cbor is being imported by criterion, a benchmarking crate. More info here https://github.com/awslabs/smithy-rs/issues/1044
+  cargo_audit_flags: --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2020-0159 --ignore RUSTSEC-2021-0127
+
 jobs:
-  audit:
+  audit-latest:
+    name: Audit Latest Dependencies
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -20,31 +37,20 @@ jobs:
         run: cargo install cargo-audit
       - name: Run audit
         run: |
-          set -eux
+          cargo audit ${{ env.cargo_audit_flags }}
 
-          # RUSTSEC-2020-0071 , RUSTSEC-2020-0159
-          # chrono, a Rust date-time crate we use for timestamp parsing was added
-          # to the RustSec vulnerability database because of a call to localtime_r.
-          # We use chrono for an extremely narrow use case of converting epoch timestamps to UTC dates
-          # (so we never invoke the problematic behavior that results from attempting to determine
-          # the local time of the current platform).
-          #
-          # Chrono's only use is as an optional feature in `aws-smithy-types-convert`, for
-          # the narrow use-case of converting from the SDK's `DateTime` into chrono types,
-          # and we never invoke the problematic behavior that results from attempting to
-          # determine the local time of the current platform.
-          #
-          # RUSTSEC-2021-0127
-          # serde_cbor is being imported by criterion, a benchmarking crate. More info here https://github.com/awslabs/smithy-rs/issues/1044
-          CARGO_AUDIT_FLAGS="\
-            --ignore RUSTSEC-2020-0071 \
-            --ignore RUSTSEC-2020-0159 \
-            --ignore RUSTSEC-2021-0127 \
-          "
-
-          echo "Auditing the latest dependencies"
-          cargo audit ${CARGO_AUDIT_FLAGS}
-
-          echo "Downgrading dependencies to minimal versions and auditing"
+  audit-minimal-versions:
+    name: Audit Minimal Versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.rust_version }}
+          default: true
+      - name: install cargo audit
+        run: cargo install cargo-audit
+      - name: Run audit
+        run: |
           cargo update -Zminimal-versions
-          cargo audit ${CARGO_AUDIT_FLAGS}
+          cargo audit ${{ env.cargo_audit_flags }}


### PR DESCRIPTION
## Motivation and Context
Currently, the audit workflow only checks the latest dependency versions. This PR updates it to check both the latest and the oldest possible so that the minimal versions can be updated in future releases if needed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
