### PR TITLE
Upgrade the canary to the new MSRV

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -4,7 +4,7 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 env:
-  tool_rust_version: 1.58.1
+  tool_rust_version: 1.61.0
 
 jobs:
   generate-canary-matrix:
@@ -28,7 +28,8 @@ jobs:
         # as a matrix definition. Rust versions to test against are arguments to this script.
         run: |
           cargo build
-          echo "::set-output name=matrix::$(cargo run -- generate-matrix --sdk-versions 3 --rust-versions 1.58.1 1.59.0 1.60.0 1.61.0)"
+          # Rust versions should just be the MSRV and the latest stable compiler
+          echo "::set-output name=matrix::$(cargo run -- generate-matrix --sdk-versions 3 --rust-versions 1.61.0 stable)"
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,8 +13,8 @@ name: CI
 env:
   SDK_BATCH_COUNT: 12
   EXAMPLES_BATCH_COUNT: 1
-  RUST_VERSIONS: "1.58.1"
-  RUST_VERSION: "1.58.1"
+  RUST_VERSIONS: "1.61.0"
+  RUST_VERSION: "1.61.0"
 
 jobs:
   generate-test-sdk-matrix:


### PR DESCRIPTION
## Motivation and Context
This bumps the canary to the new MSRV which might get it passing again.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
