### PR TITLE
Compile the canary against musl

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -60,6 +60,11 @@ jobs:
           path: smithy-rs
           # Fetch all history so that the runner can change to different commits
           fetch-depth: 0
+      # Each canary run uses a different Rust version, and the `rust-toolchain.toml`
+      # file interferes with that version selection.
+      - name: Delete `rust-toolchain.toml`
+        working-directory: smithy-rs
+        run: rm rust-toolchain.toml
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust_version }}

--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -83,4 +83,5 @@ jobs:
             run --sdk-release-tag ${SDK_RELEASE_TAG} \
                 --lambda-code-s3-bucket-name ${LAMBDA_CODE_S3_BUCKET_NAME} \
                 --lambda-test-s3-bucket-name ${LAMBDA_TEST_S3_BUCKET_NAME} \
-                --lambda-execution-role-arn ${LAMBDA_EXECUTION_ROLE_ARN}
+                --lambda-execution-role-arn ${LAMBDA_EXECUTION_ROLE_ARN} \
+                --musl


### PR DESCRIPTION
This PR fixes the canary.

I'm not really sure how it succeeded before since it wasn't compiling against musl. Perhaps it was a coincidence between the Ubuntu version the Lambda compiled on, and the Amazon Linux 2 version it ran on. This PR makes it compile against musl and overrides the `rust-toolchain.yml` file in smithy-rs so that the correct toolchain version is used.

Successful canary run: https://github.com/awslabs/aws-sdk-rust/actions/runs/3414713195/jobs/5683095244

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
