### PR TITLE
Make the info-level provide_credentials trace a debug trace

### DIFF
--- a/sdk/aws-config/src/default_provider/credentials.rs
+++ b/sdk/aws-config/src/default_provider/credentials.rs
@@ -70,7 +70,7 @@ impl DefaultCredentialsChain {
     async fn credentials(&self) -> credentials::Result {
         self.0
             .provide_credentials()
-            .instrument(tracing::info_span!("provide_credentials", provider = %"default_chain"))
+            .instrument(tracing::trace_span!("provide_credentials", provider = %"default_chain"))
             .await
     }
 }


### PR DESCRIPTION
This info span is very verbose:

```
2022-12-08T20:01:13Z INFO  aws_config::profile::credentials] constructed abstract provider from config file chain=ProfileChain { base: AccessKey(Credentials { provider_name: "ProfileFile", access_key_id: "X", secret_access_key: "** redacted **" }), chain: [] }
[2022-12-08T20:01:13Z INFO  aws_config::profile::credentials::exec] first credentials will be loaded from AccessKey(Credentials { provider_name: "ProfileFile", access_key_id: "X", secret_access_key: "** redacted **" }) base=AccessKey(Credentials { provider_name: "ProfileFile", access_key_id: "X", secret_access_key: "** redacted **" })
[2022-12-08T20:01:13Z INFO  aws_config::profile::credentials] loaded base credentials creds=Credentials { provider_name: "ProfileFile", access_key_id: "X", secret_access_key: "** redacted **" }
[2022-12-08T20:01:13Z INFO  aws_config::default_provider::credentials] provide_credentials; provider=default_chain
[2022-12-08T20:01:13Z INFO  aws_config::default_provider::credentials] provide_credentials; provider=default_chain
[2022-12-08T20:01:13Z INFO  aws_config::default_provider::credentials] provide_credentials; provider=default_chain
[2022-12-08T20:01:13Z INFO  aws_config::default_provider::credentials] provide_credentials; provider=default_chain
[2022-12-08T20:01:13Z INFO  aws_config::default_provider::credentials] provide_credentials; provider=default_chain
[2022-12-08T20:01:13Z INFO  aws_config::default_provider::credentials] provide_credentials; provider=default_chain
[2022-12-08T20:01:13Z INFO  aws_config::default_provider::credentials] provide_credentials; provider=default_chain
[2022-12-08T20:01:13Z INFO  aws_config::default_provider::credentials] provide_credentials; provider=default_chain
[2022-12-08T20:01:13Z INFO  aws_config::default_provider::credentials] provide_credentials; provider=default_chain
[2022-12-08T20:01:13Z INFO  aws_config::default_provider::credentials] provide_credentials; provider=default_chain
[2022-12-08T20:01:13Z INFO  aws_config::default_provider::credentials] provide_credentials; provider=default_chain
[2022-12-08T20:01:13Z INFO  aws_config::default_provider::credentials] provide_credentials; provider=default_chain
... Repeated many, many times
```

This is quite annoying, as the `info` log level shouldn't really be spammed with a relatively useless debug message like this.

I'm proposing to change this to a trace instead, which means you no longer need to exclude it from your logging config in every project you use `aws-config`