### PR TITLE
Pass Rust version to canary runner

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -39,6 +39,7 @@ jobs:
     env:
       AWS_DEFAULT_REGION: us-west-2
       CARGO_INCREMENTAL: "0"
+      RUST_VERSION: ${{ matrix.rust_version }}
       SDK_RELEASE_TAG: ${{ matrix.sdk_release_tag }}
       LAMBDA_CODE_S3_BUCKET_NAME: ${{ secrets.CANARY_LAMBDA_CODE_S3_BUCKET }}
       LAMBDA_TEST_S3_BUCKET_NAME: ${{ secrets.CANARY_LAMBDA_TEST_S3_BUCKET }}
@@ -83,7 +84,8 @@ jobs:
         working-directory: smithy-rs/tools/ci-cdk/canary-runner
         run: |
           cargo run -- \
-            run --sdk-release-tag ${SDK_RELEASE_TAG} \
+            run --rust-version ${RUST_VERSION} \
+                --sdk-release-tag ${SDK_RELEASE_TAG} \
                 --lambda-code-s3-bucket-name ${LAMBDA_CODE_S3_BUCKET_NAME} \
                 --lambda-test-s3-bucket-name ${LAMBDA_TEST_S3_BUCKET_NAME} \
                 --lambda-execution-role-arn ${LAMBDA_EXECUTION_ROLE_ARN} \


### PR DESCRIPTION
## Motivation and Context
This is needed by https://github.com/awslabs/smithy-rs/pull/2135 to fix the canary. These changes were tested by temporarily changing the smithy-rs branch to `jdisanti-fix-canary` and running it against this branch: https://github.com/awslabs/aws-sdk-rust/actions/runs/3762089873

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
