### PR TITLE
Fix Cargo.toml workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,7 @@
 exclude = [
     "tests/aws-smithy-runtime-test",
     "tests/using-native-tls-instead-of-rustls",
-    "tests/no-default-features"
-]
-members = [
+    "tests/no-default-features",
     "examples/apigateway",
     "examples/apigatewaymanagement",
     "examples/applicationautoscaling",
@@ -59,7 +57,9 @@ members = [
     "examples/test-utils",
     "examples/testing",
     "examples/tls",
-    "examples/transcribestreaming",
+    "examples/transcribestreaming"
+]
+members = [
     "sdk/accessanalyzer",
     "sdk/account",
     "sdk/acm",


### PR DESCRIPTION
Fixing the root cargo.toml (moving examples to the `exclucde` list) to unblock the release process.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
