### PR TITLE
Fix up metadata for release 2023-04-12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 <!-- Do not manually edit this file. Use the `changelogger` tool. -->
 April 12th, 2023
 ================
+**New this release:**
+- 🐛🎉 ([smithy-rs#2562](https://github.com/awslabs/smithy-rs/issues/2562)) Update the `std::fmt::Debug` implementation for `aws-sigv4::SigningParams` so that it will no longer print sensitive information.
+
 **Crate Versions**
 <details>
 <summary>Click to expand to view crate versions...</summary>

--- a/versions.toml
+++ b/versions.toml
@@ -2138,11 +2138,6 @@ category = 'SmithyRuntime'
 version = '0.55.1'
 source_hash = '06e997b08d8140d9247d5dbfec1af6bb4a34f658545f096cd31aeca2319ce37d'
 
-[crates.aws-smithy-runtime-test]
-category = 'SmithyRuntime'
-version = '0.1.0'
-source_hash = '2d9cb864a5b7791121d3650d9d26e4f0fe67099b59d9ece886ff67951ebb3efa'
-
 [crates.aws-smithy-types]
 category = 'SmithyRuntime'
 version = '0.55.1'


### PR DESCRIPTION
## Motivation and Context
This PR manually removes the `aws-smithy-runtime-test` crate from `versions.toml` and ports a `CHANGELOG` entry from https://github.com/awslabs/smithy-rs/pull/2562.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
