### PR TITLE
Remove unpublished runtime crates from versions table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -369,7 +369,6 @@ April 12th, 2023
 |aws-smithy-query|0.55.1|
 |aws-smithy-runtime|0.55.1|
 |aws-smithy-runtime-api|0.55.1|
-|aws-smithy-runtime-test|0.1.0|
 |aws-smithy-types|0.55.1|
 |aws-smithy-types-convert|0.55.1|
 |aws-smithy-xml|0.55.1|
@@ -742,9 +741,6 @@ April 5th, 2023
 |aws-smithy-json|0.55.0|
 |aws-smithy-protocol-test|0.55.0|
 |aws-smithy-query|0.55.0|
-|aws-smithy-runtime|0.55.0|
-|aws-smithy-runtime-api|0.55.0|
-|aws-smithy-runtime-test|0.1.0|
 |aws-smithy-types|0.55.0|
 |aws-smithy-types-convert|0.55.0|
 |aws-smithy-xml|0.55.0|


### PR DESCRIPTION
## Motivation and Context
This PR will keep crate versions table in `CHANGELOG.md` in sync with https://github.com/awslabs/aws-sdk-rust/pull/768 and https://github.com/awslabs/aws-sdk-rust/pull/787.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
