### PR TITLE
making arguments consistent with comments

### DIFF
--- a/examples/config/src/bin/config-helloworld.rs
+++ b/examples/config/src/bin/config-helloworld.rs
@@ -54,8 +54,8 @@ async fn get_history(client: &Client, id: &str, res: ResourceType) -> Result<(),
 /// NOTE: AWS Config must be enabled to discover resources
 /// # Arguments
 ///
-/// * `-resource_id RESOURCE-ID` - The ID of the resource.
-/// * `-resource_type RESOURCE-TYPE` - The type of resource, such as **AWS::EC2::SecurityGroup**.
+/// * `[--resource_id RESOURCE-ID]` - The ID of the resource.
+/// * `[--resource_type RESOURCE-TYPE]` - The type of resource, such as **AWS::EC2::SecurityGroup**.
 /// * `[-r REGION]` - The AWS Region in which the client is created.
 ///   If not supplied, uses the value of the **AWS_REGION** environment variable.
 ///   If the environment variable is not set, defaults to **us-west-2**.

--- a/examples/ecr/src/bin/list-images.rs
+++ b/examples/ecr/src/bin/list-images.rs
@@ -55,7 +55,7 @@ async fn show_images(
 /// Lists the images in an Amazon Elastic Container Registry repository.
 /// # Arguments
 ///
-/// * `[-repository REPOSITORY]` - The ECR repository containing images.
+/// * `[--repository REPOSITORY]` - The ECR repository containing images.
 /// * `[-r REGION]` - The Region in which the client is created.
 ///   If not supplied, uses the value of the **AWS_REGION** environment variable.
 ///   If the environment variable is not set, defaults to **us-west-2**.

--- a/examples/eks/src/bin/create-delete-cluster.rs
+++ b/examples/eks/src/bin/create-delete-cluster.rs
@@ -22,7 +22,7 @@ struct Opt {
 
     /// The Amazon Resource Name (ARN) of the IAM role that provides permissions
     /// for the Kubernetes control plane to make calls to AWS API operations on your behalf.
-    #[structopt(long)]
+    #[structopt(short, long)]
     arn: String,
 
     /// The subnet IDs for your Amazon EKS nodes.

--- a/examples/firehose/src/bin/put-records-batch.rs
+++ b/examples/firehose/src/bin/put-records-batch.rs
@@ -17,11 +17,11 @@ use clap::Parser;
 #[derive(Debug, Parser)]
 struct Opt {
     /// The AWS Region.
-    #[structopt(long)]
+    #[structopt(short, long)]
     region: Option<String>,
 
     /// Whether to display additional information.
-    #[structopt(long)]
+    #[structopt(short, long)]
     verbose: bool,
 
     /// Whether to display additional information.

--- a/examples/snowball/src/bin/create-address.rs
+++ b/examples/snowball/src/bin/create-address.rs
@@ -76,16 +76,16 @@ async fn add_address(client: &Client, address: Address) -> Result<(), Error> {
 /// * `[-r REGION]` - The Region in which the client is created.
 ///    If not supplied, uses the value of the **AWS_REGION** environment variable.
 ///    If the environment variable is not set, defaults to **us-west-2**.
-/// * `--city CITY` - The required city portion of the address.
+/// * `[--city CITY]` - The required city portion of the address.
 /// * `[--company COMPANY]` - The company portion of the address.
-/// * `--country COUNTRY` - The required country portion of the address.
+/// * `[--country COUNTRY]` - The required country portion of the address.
 /// * `[--landmark LANDMARK]` - The landmark portion of the address.
-/// * `--name NAME` - The required name portion of the address.
-/// * `--phone-number PHONE-NUMBER` - The required phone number portion of the address.
-/// * `--postal-code POSTAL-CODE` - The required postal code (zip in USA) portion of the address.
+/// * `[--name NAME]` - The required name portion of the address.
+/// * `[--phone-number PHONE-NUMBER]` - The required phone number portion of the address.
+/// * `[--postal-code POSTAL-CODE]` - The required postal code (zip in USA) portion of the address.
 /// * `[--prefecture-or-district PREFECTURE-OR-DISTRICT]` - The prefecture or district portion of the address.
-/// * `--state STATE` - The required state portion of the address. It must be (two is best) upper-case letters.
-/// * `--street1 STREET1` - The required first street portion of the address.
+/// * `[--state STATE]` - The required state portion of the address. It must be (two is best) upper-case letters.
+/// * `[--street1 STREET1]` - The required first street portion of the address.
 /// * `[--street2 STREET2]` - The second street portion of the address.
 /// * `[--street3 STREET3]` - The third street portion of the address.
 /// * `[-v]` - Whether to display additional information.

--- a/examples/sts/src/bin/assume-role.rs
+++ b/examples/sts/src/bin/assume-role.rs
@@ -14,11 +14,11 @@ use clap::Parser;
 #[derive(Debug, Parser)]
 struct Opt {
     /// The AWS Region.
-    #[structopt(long)]
+    #[structopt(short, long)]
     region: Option<String>,
 
     /// Whether to display additional information.
-    #[structopt(long)]
+    #[structopt(short, long)]
     verbose: bool,
 
     /// Whether to display additional information.

--- a/examples/sts/src/bin/get-caller-identity.rs
+++ b/examples/sts/src/bin/get-caller-identity.rs
@@ -13,11 +13,11 @@ use std::fmt::Debug;
 #[derive(Debug, Parser)]
 struct Opt {
     /// The AWS Region.
-    #[structopt(long)]
+    #[structopt(short, long)]
     region: Option<String>,
 
     /// Whether to display additional information.
-    #[structopt(long)]
+    #[structopt(short, long)]
     verbose: bool,
 }
 


### PR DESCRIPTION
<!--

IMPORTANT:

> Making changes to examples? 

Be sure to make example changes in the awsdocs/aws-doc-sdk-examples repository (https://github.com/awsdocs/aws-doc-sdk-examples).
The examples in aws-sdk-rust are copied from the `rust_dev_preview/` directory in that repository.


> Making changes to code?

All the code in aws-sdk-rust is auto-generated by smithy-rs (https://github.com/awslabs/smithy-rs).
Changes to code need to be made in that repository.

-->


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
There were some inconsistencies between expected cli arguments in comments and `structopt` macro arguments. 
<!-- If it fixes an open issue, please link to the issue here -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
