### PR TITLE
Update stale_issue.yaml

### DIFF
--- a/.github/workflows/stale_issue.yaml
+++ b/.github/workflows/stale_issue.yaml
@@ -32,8 +32,7 @@ jobs:
         # Issue timing
         days-before-stale: 7
         days-before-close: 4
-        # TODO: Change back to 365 once the SDK is GA
-        days-before-ancient: 10000
+        days-before-ancient: 36500
 
         # If you don't want to mark a issue as being ancient based on a
         # threshold of "upvotes", you can set this here. An "upvote" is


### PR DESCRIPTION
setting stale issue bot to only auto close after 36,500 days for all repos

<!--

IMPORTANT:

> Making changes to examples? 

Be sure to make example changes in the awsdocs/aws-doc-sdk-examples repository (https://github.com/awsdocs/aws-doc-sdk-examples).
The examples in aws-sdk-rust are copied from the `rust_dev_preview/` directory in that repository.


> Making changes to code?

All the code in aws-sdk-rust is auto-generated by smithy-rs (https://github.com/awslabs/smithy-rs).
Changes to code need to be made in that repository.

-->


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
