### PR TITLE
Fix wrong service name

### DIFF
--- a/examples/ssm/src/bin/describe-parameters.rs
+++ b/examples/ssm/src/bin/describe-parameters.rs
@@ -53,7 +53,7 @@ async fn main() -> Result<(), Error> {
     println!();
 
     if verbose {
-        println!("SQS client version: {}", PKG_VERSION);
+        println!("SSM client version: {}", PKG_VERSION);
         println!(
             "Region:             {}",
             region_provider.region().await.unwrap().as_ref()


### PR DESCRIPTION
## Motivation and Context
Typo fix in service name on SSM example.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
