### PR TITLE
Update send-email.rs

### DIFF
--- a/examples/ses/src/bin/send-email.rs
+++ b/examples/ses/src/bin/send-email.rs
@@ -57,7 +57,7 @@ async fn send_message(
 
     let cs: String = contacts
         .iter()
-        .map(|i| i.email_address().unwrap_or_default())
+        .map(|i| format!("{},", i.email_address().unwrap_or_default()))
         .collect();
 
     let dest = Destination::builder().to_addresses(cs).build();


### PR DESCRIPTION
cs is being returned without a comma. eg:
user@example.comuser2@example.com...
Causes Exception:
Error: BadRequestException(BadRequestException { message: Some("Illegal address"), meta: ErrorMetadata { code: Some("BadRequestException"), message: Some("Illegal address"), extras: Some({"aws_request_id": "da0bf20a-52b3-4acc-bb22-eec27cf68322"}) } })

If the contact list has more that one contact it will fail.

<!--

IMPORTANT:

> Making changes to examples? 

Be sure to make example changes in the awsdocs/aws-doc-sdk-examples repository (https://github.com/awsdocs/aws-doc-sdk-examples).
The examples in aws-sdk-rust are copied from the `rust_dev_preview/` directory in that repository.


> Making changes to code?

All the code in aws-sdk-rust is auto-generated by smithy-rs (https://github.com/awslabs/smithy-rs).
Changes to code need to be made in that repository.

-->


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
