### PR TITLE
Fix instructions on debug logging in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -86,8 +86,8 @@ body:
         initializing it (e.g., `tracing_subscriber::fmt::init();`),
         and then setting the environment variable `RUST_LOG` before
         running your program, as follows:
-        `RUST_LOG='aws_smithy_runtime=debug,aws_runtime=debug'`
+        `RUST_LOG=debug`
         For example:
-        `RUST_LOG='aws_smithy_runtime=debug,aws_runtime=debug' cargo run`
+        `RUST_LOG=debug cargo run`
         The SDK redacts sensitive information such as auth headers in these debug logs,
         but please look through them before posting just to be sure.

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -82,8 +82,8 @@ body:
       description: |
         It's also helpful to enable debug logging and include the
         log messages as these will show the actual HTTP requests and
-        responses. You can enable this by initializing `tracing-subscriber`
-        if you haven't already (e.g., `tracing_subscriber::fmt::init();`),
+        responses. You can enable this by adding the `tracing-subscriber` crate with the `env-filter` feature,
+        initializing it (e.g., `tracing_subscriber::fmt::init();`),
         and then setting the environment variable `RUST_LOG` before
         running your program, as follows:
         `RUST_LOG='aws_smithy_runtime=debug,aws_runtime=debug'`

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -80,14 +80,14 @@ body:
     attributes:
       label: Logs
       description: |
-        It's also helpful to enable trace logging and include the
+        It's also helpful to enable debug logging and include the
         log messages as these will show the actual HTTP requests and
         responses. You can enable this by initializing `tracing-subscriber`
         if you haven't already (e.g., `tracing_subscriber::fmt::init();`),
         and then setting the environment variable `RUST_LOG` before
         running your program, as follows:
-        `RUST_LOG='aws_smithy_http_tower::dispatch=trace,aws_smithy_http::middleware=trace'`
+        `RUST_LOG='aws_smithy_runtime=debug,aws_runtime=debug'`
         For example:
-        `RUST_LOG='aws_smithy_http_tower::dispatch=trace,aws_smithy_http::middleware=trace' cargo run`
-        The SDK redacts sensitive information such as auth headers in these trace logs,
+        `RUST_LOG='aws_smithy_runtime=debug,aws_runtime=debug' cargo run`
+        The SDK redacts sensitive information such as auth headers in these debug logs,
         but please look through them before posting just to be sure.


### PR DESCRIPTION
These instructions became outdated with the orchestrator release.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
