### PR TITLE
Replace `minimum-versions` with `direct-minimal-versions`

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -74,5 +74,5 @@ jobs:
           done
 
           # Generate a lockfile at the minimum possible versions
-          cargo generate-lockfile -Zminimal-versions
+          cargo generate-lockfile -Zdirect-minimal-versions
           cargo audit ${{ env.cargo_audit_flags }}

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
   pull_request:
 env:
-  rust_version: nightly-2022-07-25
+  rust_version: nightly-2023-07-31
 
   # RUSTSEC-2020-0071 , RUSTSEC-2020-0159
   # chrono, a Rust date-time crate we use for timestamp parsing was added

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,8 +10,8 @@ name: CI
 env:
   SDK_BATCH_COUNT: 12
   EXAMPLES_BATCH_COUNT: 1
-  RUST_VERSIONS: "1.68.2"
-  RUST_VERSION: "1.68.2"
+  RUST_VERSIONS: "1.70.0"
+  RUST_VERSION: "1.70.0"
 
 jobs:
   generate-test-sdk-matrix:


### PR DESCRIPTION
This will remove / reduce downstream noise related to minimum version resolution.

I also upped the examples compilation version to 1.70 so that CI will pass 

<!--

IMPORTANT:

> Making changes to examples? 

Be sure to make example changes in the awsdocs/aws-doc-sdk-examples repository (https://github.com/awsdocs/aws-doc-sdk-examples).
The examples in aws-sdk-rust are copied from the `rust_dev_preview/` directory in that repository.


> Making changes to code?

All the code in aws-sdk-rust is auto-generated by smithy-rs (https://github.com/awslabs/smithy-rs).
Changes to code need to be made in that repository.

-->


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
