### PR TITLE
Manual Patch of smithy_rs revision

### DIFF
--- a/versions.toml
+++ b/versions.toml
@@ -1,4 +1,4 @@
-smithy_rs_revision = '1297c8c7d3d382ac8c65dad9a2502c56b3311150'
+smithy_rs_revision = '96aa1fcc388a5a9d75ce996e1562955602b46b57'
 aws_doc_sdk_examples_revision = 'dc64af92d9c1780e628ab8b9f665e0490dfad6c8'
 
 [manual_interventions]


### PR DESCRIPTION
This manual intervention moves the smithy_rs_revision to one commit past the addition of the `httpPayload` trait. This will allow the SDK sync task to succeed.

<!--

IMPORTANT:

> Making changes to examples? 

Be sure to make example changes in the awsdocs/aws-doc-sdk-examples repository (https://github.com/awsdocs/aws-doc-sdk-examples).
The examples in aws-sdk-rust are copied from the `rust_dev_preview/` directory in that repository.


> Making changes to code?

All the code in aws-sdk-rust is auto-generated by smithy-rs (https://github.com/awslabs/smithy-rs).
Changes to code need to be made in that repository.

-->


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
