### PR TITLE
Update zip_next to 0.11.0

### DIFF
--- a/examples/cross_service/photo_asset_management/Cargo.toml
+++ b/examples/cross_service/photo_asset_management/Cargo.toml
@@ -64,6 +64,6 @@ version = "1.3.1"
 features = ["v4"]
 
 [dependencies.zip_next]
-version = "0.10.2"
+version = "0.11.0"
 default-features = false
 features = ["chrono", "deflate"]


### PR DESCRIPTION
This pull request updates zip_next to 0.11.0.
## Motivation and Context
This version provides fixes for several bugs that were found by overhauling the fuzz tests. The interface to read archives and decompress files remains the same.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
