### PR TITLE
Switch to debug logging for credential fetches

### DIFF
--- a/sdk/aws-config/src/profile/credentials/exec.rs
+++ b/sdk/aws-config/src/profile/credentials/exec.rs
@@ -160,12 +160,12 @@ impl ProviderChain {
                 }
             }
         };
-        tracing::info!(base = ?repr.base(), "first credentials will be loaded from {:?}", repr.base());
+        tracing::debug!(base = ?repr.base(), "first credentials will be loaded from {:?}", repr.base());
         let chain = repr
             .chain()
             .iter()
             .map(|role_arn| {
-                tracing::info!(role_arn = ?role_arn, "which will be used to assume a role");
+                tracing::debug!(role_arn = ?role_arn, "which will be used to assume a role");
                 AssumeRoleProvider {
                     role_arn: role_arn.role_arn.into(),
                     external_id: role_arn.external_id.map(Into::into),

--- a/sdk/aws-smithy-runtime/src/client/identity/cache/lazy.rs
+++ b/sdk/aws-smithy-runtime/src/client/identity/cache/lazy.rs
@@ -354,7 +354,7 @@ impl ResolveCachedIdentity for LazyCache {
                             // `cache.get_or_load`, logging inside `cache.get_or_load` ensures that it is emitted
                             // only once for the first thread that succeeds in populating a cache value.
                             let printable = DateTime::from(expiration);
-                            tracing::info!(
+                            tracing::debug!(
                                 new_expiration=%printable,
                                 valid_for=?expiration.duration_since(time_source.now()).unwrap_or_default(),
                                 partition=?partition,


### PR DESCRIPTION
## Motivation and Context

These messages really feel like debug messages. After starting to use the SDK, it's somewhat jarring to see a bunch of pretty irrelevant information outputted and it is also somewhat annoying to disable info logging just for the AWS SDK.

It's of course simpleish and possible to do, but it's just that these messages don't seem to be actually useful information:

```
2024-03-21T19:59:29.282801Z  INFO x:lazy_load_identity: aws_config::profile::credentials: constructed abstract provider from config file chain=ProfileChain { base: CredentialProcess("xxx ** arguments redacted **"), chain: [] }
2024-03-21T19:59:29.283008Z  INFO x:lazy_load_identity: aws_config::profile::credentials::exec: first credentials will be loaded from CredentialProcess("xxx ** arguments redacted **") base=CredentialProcess("xxx ** arguments redacted **")
2024-03-21T19:59:30.613478Z  INFO x:lazy_load_identity: aws_config::profile::credentials: loaded base credentials creds=Credentials { provider_name: "CredentialProcess", access_key_id: "ASIAWXV3OIC7xxx", secret_access_key: "** redacted **", expires_after: "2024-03-21T20:10:36Z" }
``` 

What _information_ is this actually giving me? That it worked as expected Excellent! But I don't need to see that logged to know that.

The fix is to just disable info logging in the SDK, but info messages _can be useful_ - I don't really want to disable it wholesale.

Can we just change these to a more appropriate debug level?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
