### PR TITLE
Provide endpoint_url via env var or profile

### DIFF
--- a/sdk/aws-config/src/default_provider.rs
+++ b/sdk/aws-config/src/default_provider.rs
@@ -51,3 +51,6 @@ pub mod use_dual_stack;
 /// Default access token provider chain
 #[cfg(feature = "sso")]
 pub mod token;
+
+/// Default endpoint-url provider chain
+pub mod endpoint_url;

--- a/sdk/aws-config/src/default_provider/endpoint_url.rs
+++ b/sdk/aws-config/src/default_provider/endpoint_url.rs
@@ -1,0 +1,125 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use crate::environment::parse_bool;
+use crate::provider_config::ProviderConfig;
+use crate::standard_property::StandardProperty;
+use aws_smithy_types::error::display::DisplayErrorContext;
+
+mod env {
+    pub(super) const ENDPOINT_URL: &str = "AWS_ENDPOINT_URL";
+    pub(super) const IGNORE_CONFIGURED_ENDPOINT_URLS: &str = "AWS_IGNORE_CONFIGURED_ENDPOINT_URLS";
+}
+
+mod profile_key {
+    pub(super) const ENDPOINT_URL: &str = "endpoint_url";
+    pub(super) const IGNORE_CONFIGURED_ENDPOINT_URLS: &str = "ignore_configured_endpoint_urls";
+}
+
+/// Load the value for "endpoint_url"
+///
+/// This checks the following sources:
+/// 1. The environment variable `AWS_ENDPOINT_URL=http://localhost:1234'
+/// 2. The profile key `endpoint_url=http://localhost:1234`
+pub async fn use_endpoint_url_provider(provider_config: &ProviderConfig) -> Option<String> {
+    let ignore: bool = StandardProperty::new()
+        .env(env::IGNORE_CONFIGURED_ENDPOINT_URLS)
+        .profile(profile_key::IGNORE_CONFIGURED_ENDPOINT_URLS)
+        .validate(provider_config, parse_bool)
+        .await
+        .map_err(
+            |err| tracing::warn!(err = %DisplayErrorContext(&err), "invalid value for ignore_configured_endpoint_urls setting"),
+        )
+        .unwrap_or(Some(false))
+        .unwrap_or_default();
+    if ignore {
+        return None;
+    }
+    StandardProperty::new()
+        .env(env::ENDPOINT_URL)
+        .profile(profile_key::ENDPOINT_URL)
+        .load(provider_config)
+        .await
+        .map(|(v, _ctx)| return v.as_ref().to_string())
+}
+
+#[cfg(test)]
+mod test {
+    use crate::default_provider::endpoint_url::use_endpoint_url_provider;
+    use crate::profile::profile_file::{ProfileFileKind, ProfileFiles};
+    use crate::provider_config::ProviderConfig;
+    use aws_types::os_shim_internal::{Env, Fs};
+    use tracing_test::traced_test;
+
+    #[tokio::test]
+    #[traced_test]
+    async fn defaults_to_none() {
+        let conf = ProviderConfig::empty();
+        assert_eq!(use_endpoint_url_provider(&conf).await, None);
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn environment_priority() {
+        let conf = ProviderConfig::empty()
+            .with_env(Env::from_slice(&[(
+                "AWS_ENDPOINT_URL",
+                "http://localhost:1",
+            )]))
+            .with_profile_config(
+                Some(
+                    ProfileFiles::builder()
+                        .with_file(ProfileFileKind::Config, "conf")
+                        .build(),
+                ),
+                None,
+            )
+            .with_fs(Fs::from_slice(&[(
+                "conf",
+                "[default]\nendpoint_url = http://localhost:2",
+            )]));
+        assert_eq!(
+            use_endpoint_url_provider(&conf).await.unwrap(),
+            "http://localhost:1".to_string()
+        );
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn log_error_on_invalid_ignore() {
+        let conf = ProviderConfig::empty().with_env(Env::from_slice(&[(
+            "AWS_IGNORE_CONFIGURED_ENDPOINT_URLS",
+            "not-a-boolean",
+        )]));
+        assert_eq!(use_endpoint_url_provider(&conf).await, None);
+        assert!(logs_contain(
+            "invalid value for ignore_configured_endpoint_urls setting"
+        ));
+        assert!(logs_contain("AWS_IGNORE_CONFIGURED_ENDPOINT_URLS"));
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn ignore_if_specified_explicitly() {
+        let conf = ProviderConfig::empty()
+            .with_env(Env::from_slice(&[
+                ("AWS_ENDPOINT_URL", "http://localhost:1"),
+                ("AWS_IGNORE_CONFIGURED_ENDPOINT_URLS", "true"),
+            ]))
+            .with_profile_config(
+                Some(
+                    ProfileFiles::builder()
+                        .with_file(ProfileFileKind::Config, "conf")
+                        .build(),
+                ),
+                None,
+            )
+            .with_fs(Fs::from_slice(&[(
+                "conf",
+                "[default]\nendpoint_url = http://localhost:2",
+            )]));
+        assert_eq!(use_endpoint_url_provider(&conf).await, None);
+    }
+}


### PR DESCRIPTION
## Motivation and Context
Closes https://github.com/awslabs/aws-sdk-rust/issues/932

Ref. https://docs.aws.amazon.com/sdkref/latest/guide/feature-ss-endpoints.html

## Note

This PR adds support for
- `AWS_ENDPOINT_URL`
- `AWS_IGNORE_CONFIGURED_ENDPOINT_URLS`

which is useful for testing implementation on AWS emulators like LocalStack.

This PR does not add support for

- `AWS_ENDPOINT_URL_<SERVICE>`

since it will be a huge change.
That will be implemented in subsequent PRs.
