### PR TITLE
Make BehaviorVersion as future-proof as the documentation specifies

### DIFF
--- a/sdk/aws-smithy-runtime-api/src/client/behavior_version.rs
+++ b/sdk/aws-smithy-runtime-api/src/client/behavior_version.rs
@@ -7,31 +7,41 @@
 
 /// Behavior major-version of the client
 ///
-/// Over time, new best-practice behaviors are introduced. However, these behaviors might not be backwards
-/// compatible. For example, a change which introduces new default timeouts or a new retry-mode for
-/// all operations might be the ideal behavior but could break existing applications.
-#[derive(Debug, Clone)]
-pub struct BehaviorVersion {}
+/// Over time, new best-practice behaviors are introduced. However, these behaviors might not be
+/// backwards compatible. For example, a change which introduces new default timeouts or a new
+/// retry-mode for all operations might be the ideal behavior but could break existing applications.
+#[derive(Clone)]
+pub struct BehaviorVersion {
+    _private: (),
+}
 
 impl BehaviorVersion {
     /// This method will always return the latest major version.
     ///
     /// This is the recommend choice for customers who aren't reliant on extremely specific behavior
-    /// characteristics. For example, if you are writing a CLI app, the latest behavior major version
-    /// is probably the best setting for you.
+    /// characteristics. For example, if you are writing a CLI app, the latest behavior major
+    /// version is probably the best setting for you.
     ///
     /// If, however, you're writing a service that is very latency sensitive, or that has written
     /// code to tune Rust SDK behaviors, consider pinning to a specific major version.
     ///
     /// The latest version is currently [`BehaviorVersion::v2023_11_09`]
     pub fn latest() -> Self {
-        Self {}
+        Self::v2023_11_09()
     }
 
     /// This method returns the behavior configuration for November 9th, 2023
     ///
     /// When a new behavior major version is released, this method will be deprecated.
     pub fn v2023_11_09() -> Self {
-        Self {}
+        Self { _private: () }
+    }
+}
+
+impl std::fmt::Debug for BehaviorVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BehaviorVersion")
+            .field("name", &"v2023_11_09")
+            .finish()
     }
 }


### PR DESCRIPTION
Fixes #1111

This is technically a breaking change but since this was released recently and it's documented that this API shouldn't be used, better now than later.
