### PR TITLE
Update expected query for `CreateMultipartUpload` protocol test

### DIFF
--- a/aws-models/s3-tests.smithy
+++ b/aws-models/s3-tests.smithy
@@ -153,8 +153,7 @@ apply CreateMultipartUpload @httpRequestTests([
         protocol: "aws.protocols#restXml",
         uri: "/object.txt",
         queryParams: [
-            "uploads",
-            "x-id=CreateMultipartUpload"
+            "uploads"
         ],
         params: {
             "Bucket": "test-bucket",


### PR DESCRIPTION
**DO NOT MERGE WHILE RELEASE IS ONGOING**

## Motivation and Context
This PR makes the same code change in https://github.com/smithy-lang/smithy-rs/pull/3628 for the same given problem. Turns out updating `s3-tests.smithy` in `aws/sdk/aws-models/s3-tests.smithy` has no effect for altering the expected result for a protocol test. Instead, we need to update the file in this repository, which is actually used in our release pipeline.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
