### PR TITLE
Update build tool version for WASI canary

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -78,6 +78,7 @@ jobs:
           CARGO_COMPONENT_VERSION: 0.13.2
         run: |
           rustup toolchain install ${{ env.rust_nightly_version }}
+          rustup component add rustfmt
           cargo +${{ env.rust_nightly_version }} install cargo-component --locked --version ${CARGO_COMPONENT_VERSION}
       - name: Compile the canary runner
         working-directory: smithy-rs/tools/ci-cdk/canary-runner

--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-    - 'canary*'
+      - "canary*"
 env:
   tool_rust_version: 1.76.0
   rust_nightly_version: nightly-2024-02-07
@@ -75,7 +75,7 @@ jobs:
       - name: Install cargo component for wasm canary
         env:
           # Must be in sync with that specified in `smithy-rs`
-          CARGO_COMPONENT_VERSION: 0.7.1
+          CARGO_COMPONENT_VERSION: 0.13.2
         run: |
           rustup toolchain install ${{ env.rust_nightly_version }}
           cargo +${{ env.rust_nightly_version }} install cargo-component --locked --version ${CARGO_COMPONENT_VERSION}


### PR DESCRIPTION
<!--

IMPORTANT:

> Making changes to examples? 

Be sure to make example changes in the awsdocs/aws-doc-sdk-examples repository (https://github.com/awsdocs/aws-doc-sdk-examples).
The examples in aws-sdk-rust are copied from the `rust_dev_preview/` directory in that repository.


> Making changes to code?

All the code in aws-sdk-rust is auto-generated by smithy-rs (https://github.com/awslabs/smithy-rs).
Changes to code need to be made in that repository.

-->


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here -->
Tested these changes with a manual canary run: https://github.com/awslabs/aws-sdk-rust/actions/runs/9575014647

And have a matching PR in smithy-rs: https://github.com/smithy-lang/smithy-rs/pull/3701

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
