### PR TITLE
fix canary msrv to match upstream smithy-rs

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -7,7 +7,7 @@ on:
     branches:
       - "canary*"
 env:
-  tool_rust_version: 1.78.0
+  tool_rust_version: 1.81.0
   rust_nightly_version: nightly-2024-03-15
 
 jobs:


### PR DESCRIPTION
<!--

IMPORTANT:

> Making changes to examples? 

Be sure to make example changes in the awsdocs/aws-doc-sdk-examples repository (https://github.com/awsdocs/aws-doc-sdk-examples).
The examples in aws-sdk-rust are copied from the `rust_dev_preview/` directory in that repository.


> Making changes to code?

All the code in aws-sdk-rust is auto-generated by smithy-rs (https://github.com/awslabs/smithy-rs).
Changes to code need to be made in that repository.

-->


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here -->

Canary is failing on MSRV requirements that changed upstream in `smithy-rs` to 1.81. Update canary accordingly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
