### PR TITLE
fix canary install dependencies step

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -8,7 +8,7 @@ on:
       - "canary*"
 env:
   tool_rust_version: 1.81.0
-  rust_nightly_version: nightly-2024-03-15
+  rust_nightly_version: nightly-2024-09-04
 
 jobs:
   generate-canary-matrix:

--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -70,7 +70,7 @@ jobs:
           toolchain: ${{ matrix.rust_version }}
           targets: x86_64-unknown-linux-musl
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y awscli musl-dev musl-tools
+        run: sudo apt-get update && sudo apt-get install -y musl-dev musl-tools
       - name: Install cargo component for wasm canary
         env:
           # Must be in sync with that specified in `smithy-rs`

--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: Install cargo component for wasm canary
         env:
           # Must be in sync with that specified in `smithy-rs`
-          CARGO_COMPONENT_VERSION: 0.13.2
+          CARGO_COMPONENT_VERSION: 0.20.0
         run: |
           rustup toolchain install ${{ env.rust_nightly_version }}
           rustup component add rustfmt


### PR DESCRIPTION
## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here -->
Fix canary install dependencies step that is [failing](https://github.com/awslabs/aws-sdk-rust/actions/runs/12898260366/job/35965110537)

```
Package awscli is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'awscli' has no installation candidate
```

AWS CLI is installed by default on ubuntu runners. See [runner-images](https://github.com/actions/runner-images). It appears `ubuntu-latest` recently switched from 22.04 to 24.04 which may be what caused this to stop working.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
