### PR TITLE
Update nightly for Security audit GitHub action

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -4,7 +4,7 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 env:
-  rust_version: nightly-2023-07-31
+  rust_version: nightly-2024-09-04
 
   # RUSTSEC-2020-0071 , RUSTSEC-2020-0159
   # chrono, a Rust date-time crate we use for timestamp parsing was added


### PR DESCRIPTION
## Motivation and Context
The Security audit GitHub action has been broken for a month. This PR updates nightly version to fix it ([the same nightly version used by canary)](https://github.com/awslabs/aws-sdk-rust/blob/main/.github/workflows/canary.yaml#L11).

## Testing
Confirmed that Security audit [passed](https://github.com/awslabs/aws-sdk-rust/actions/runs/13338282531) against this feature branch.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
