### PR TITLE
add release config for specifying smithy-rs version as a dependency

### DIFF
--- a/.github/workflows/release-checks.yaml
+++ b/.github/workflows/release-checks.yaml
@@ -1,0 +1,30 @@
+on:
+  pull:
+    branches:
+      - main
+  workflow_dispatch:
+
+name: Release Configuration Checks
+
+jobs:
+  check-config:
+    runs-on: ubuntu-latest
+    name: Check Release config.json
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check smithy-rs version exists
+        run: |
+          SMITHY_RS_VERSION=$(jq -r ".dependencies.smithyRsVersion" config.json)
+          echo "checking smithy-rs@$SMITHY_RS_VERSION"
+          mkdir smithy-rs
+          cd smithy-rs
+          git init
+          git remote add origin https://github.com/smithy-lang/smithy-rs.git
+          
+          if git fetch origin $SMITHY_RS_VERSION; then
+            echo "smithy-rs@$SMITHY_RS_VERSION found"
+          else
+            echo "::error::no smithy-rs@$SMITHY_RS_VERSION found"
+            exit 1
+          fi
+

--- a/.github/workflows/release-checks.yaml
+++ b/.github/workflows/release-checks.yaml
@@ -1,5 +1,5 @@
 on:
-  pull:
+  pull_request:
     branches:
       - main
   workflow_dispatch:

--- a/config.json
+++ b/config.json
@@ -1,0 +1,5 @@
+{
+    "dependencies": {
+        "smithyRsVersion": "release-2025-05-09"
+    }
+}

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
     "dependencies": {
-        "smithyRsVersion": "release-2025-05-09"
+        "smithyRsVersion": "foo"
     }
 }

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
     "dependencies": {
-        "smithyRsVersion": "release-2025-05-09"
+        "smithyRsVersion": "release-2025-05-19"
     }
 }

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
     "dependencies": {
-        "smithyRsVersion": "foo"
+        "smithyRsVersion": "release-2025-05-09"
     }
 }


### PR DESCRIPTION
<!--

IMPORTANT:

> Making changes to examples? 

Be sure to make example changes in the awsdocs/aws-doc-sdk-examples repository (https://github.com/awsdocs/aws-doc-sdk-examples).
The examples in aws-sdk-rust are copied from the `rust_dev_preview/` directory in that repository.


> Making changes to code?

All the code in aws-sdk-rust is auto-generated by smithy-rs (https://github.com/awslabs/smithy-rs).
Changes to code need to be made in that repository.

-->


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here -->

* Adds a new `config.json` for specifying release configuration. Right now this just holds a new "dependencies" section for specifying the version of `smithy-rs` code generator and runtime to use when making a release. This will be picked up by the catapult release stack during release
* Adds a new CI check for verifying the config.json smithy-rs version set actually exists before being merged.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
