### PR TITLE
Revert "Update smithy-rs to release-2025-07-08 (#1315)"

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "smithyRsVersion": "release-2025-07-08"
+    "smithyRsVersion": "release-2025-06-30"
   }
 }


### PR DESCRIPTION
This reverts commit 306850137e884e26a0553f0cd60a2311fa0e3bce to avoid MRSV bump failure encountered in release
```
error: rustc 1.85.0 is not supported by the following package:
  aws-sdk-dynamodb@0.0.0-local requires rustc 1.86.0
```