### PR TITLE
Include check in release-checks.yaml to detect tools changes in smithy-rs

### DIFF
--- a/.github/workflows/release-checks.yaml
+++ b/.github/workflows/release-checks.yaml
@@ -20,7 +20,7 @@ jobs:
           cd smithy-rs
           git init
           git remote add origin https://github.com/smithy-lang/smithy-rs.git
-          
+
           if git fetch origin $SMITHY_RS_VERSION; then
             echo "smithy-rs@$SMITHY_RS_VERSION found"
           else
@@ -28,3 +28,48 @@ jobs:
             exit 1
           fi
 
+      - name: Check for tools changes in smithy-rs
+        run: |
+          SMITHY_RS_VERSION=$(jq -r ".dependencies.smithyRsVersion" config.json)
+          echo "Checking for tools changes in smithy-rs@$SMITHY_RS_VERSION"
+          cd smithy-rs
+
+          # Get the latest 10 release tags by creation date
+          git fetch origin --tags
+
+          # Get latest 10 release tags sorted by creation date (newest first)
+          LATEST_N_RELEASES=$(git tag -l "release-*" --sort=-creatordate | head -n 10)
+
+          # Find the previous release before SMITHY_RS_VERSION
+          PREV_VERSION=""
+          FOUND_CURRENT=false
+          for release in $LATEST_N_RELEASES; do
+            if [ "$FOUND_CURRENT" = true ]; then
+              PREV_VERSION="$release"
+              break
+            fi
+            if [ "$release" = "$SMITHY_RS_VERSION" ]; then
+              FOUND_CURRENT=true
+            fi
+          done
+
+          if [ -n "$PREV_VERSION" ]; then
+            # Remove "release-" prefix for display
+            PREV_VERSION_NUM=${PREV_VERSION#release-}
+            CURRENT_VERSION_NUM=${SMITHY_RS_VERSION#release-}
+            echo "Previous version: $PREV_VERSION_NUM"
+            echo "Current version: $CURRENT_VERSION_NUM"
+
+            # Check if tools directory has changes between versions
+            if git diff --name-only $PREV_VERSION..$SMITHY_RS_VERSION | grep -q "^tools/"; then
+              echo "::warning::Tools changes detected between $PREV_VERSION_NUM and $CURRENT_VERSION_NUM"
+              echo "::warning::Release infrastructure must be updated to use the new tools before updating config.json"
+              git diff --name-only $PREV_VERSION..$SMITHY_RS_VERSION | grep "^tools/" | while read file; do
+                echo "::warning::Changed: $file"
+              done
+            else
+              echo "No tools changes detected"
+            fi
+          else
+            echo "::warning::Could not determine previous release version for comparison"
+          fi


### PR DESCRIPTION
This PR updates `release-checks.yaml` to include an additional check (written by `qcli`) if there are changes in [the tools directory](https://github.com/smithy-lang/smithy-rs/tree/main/tools) within the smithy-rs repository.

If so, we should update the Docker image used in the release pipeline first, before merging the updated `config.json` to the main branch.

While the additional check issues a warning if it detects changes in the `tools` directory, and it doesn't fail CI. In future, we can improve the check so that it's triggered only when changes are made to `config.json` in a pull request, for instance.

[Dry-run](https://github.com/awslabs/aws-sdk-rust/actions/runs/16429391333/job/46427498877#step:4:419)