### PR TITLE
Update smithy-rs to release-2025-08-04

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "smithyRsVersion": "release-2025-07-25"
+    "smithyRsVersion": "release-2025-08-04"
   }
 }


### PR DESCRIPTION
Updates the smithy-rs code generator and runtime dependencies to [release-2025-08-04](https://github.com/smithy-lang/smithy-rs/releases/tag/release-2025-08-04).

No code changes to the `tools` directory since the last release (confirmed by running this in `smithy-rs`):
```
git diff --name-only release-2025-07-25..release-2025-08-04 | grep "^tools/"
```
