### PR TITLE
rollback smithy-rs to 2025-08-13

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "smithyRsVersion": "release-2025-08-18"
+    "smithyRsVersion": "release-2025-08-13"
   }
 }


### PR DESCRIPTION
<!--

IMPORTANT:

> Making changes to examples? 

Be sure to make example changes in the awsdocs/aws-doc-sdk-examples repository (https://github.com/awsdocs/aws-doc-sdk-examples).
The examples in aws-sdk-rust are copied from the `rust_dev_preview/` directory in that repository.


> Making changes to code?

All the code in aws-sdk-rust is auto-generated by smithy-rs (https://github.com/awslabs/smithy-rs).
Changes to code need to be made in that repository.

-->


## Motivation and Context
Rollback smithy-rs update (https://github.com/awslabs/aws-sdk-rust/pull/1343). This is causing an issue with internal performance testing steps in our release pipeline (not performance related but due to Cargo and versioning (internal ref: `P288989567`). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
