### PR TITLE
Bump Canary rust version to 1.88

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -7,7 +7,7 @@ on:
     branches:
       - "canary*"
 env:
-  tool_rust_version: 1.86.0
+  tool_rust_version: 1.88.0
   rust_nightly_version: nightly-2025-08-06
 
 jobs:


### PR DESCRIPTION
<!--

IMPORTANT:

> Making changes to examples? 

Be sure to make example changes in the awsdocs/aws-doc-sdk-examples repository (https://github.com/awsdocs/aws-doc-sdk-examples).
The examples in aws-sdk-rust are copied from the `rust_dev_preview/` directory in that repository.


> Making changes to code?

All the code in aws-sdk-rust is auto-generated by smithy-rs (https://github.com/awslabs/smithy-rs).
Changes to code need to be made in that repository.

-->


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here -->

Canaries were failing due to still running on 1.86 after we bumped our MSRV to 1.88 on the most recent release.

Test canary running at  https://github.com/awslabs/aws-sdk-rust/actions/runs/19078560933

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
