### PR TITLE
Detect tools changes in smithy-rs since the last update to config.json

### DIFF
--- a/.github/workflows/release-checks.yaml
+++ b/.github/workflows/release-checks.yaml
@@ -52,7 +52,7 @@ jobs:
           if echo "$CHANGED_FILES" | grep -q "^tools/"; then
             echo "::error::Tools changes detected between $MAIN_SMITHY_RS_VERSION and $CURRENT_SMITHY_RS_VERSION"
             echo "$CHANGED_FILES" | grep "^tools/"
-            echo "::error::Release infrastructure must specify the updated image tag before updating config.json. If the updated image tag has already been specified, use the bot user to force-merge this PR to main."
+            echo "::error::Complete an internal release before updating config.json. After completion, use the bot user to force-merge this PR to main."
             exit 1
           else
             echo "No tools changes detected - check passed"


### PR DESCRIPTION
## Motivation and Context
When modifying the [tools](https://github.com/smithy-lang/smithy-rs/tree/main/tools) directory in `smithy-rs`, we must update our production release infrastructure with a new container image tag before updating `smithyRsVersion` in `config.json`. Failing to do so causes production build failures.

For instance, during MSRV updates, we modify the [Dockerfile](https://github.com/smithy-lang/smithy-rs/blob/main/tools/ci-build/Dockerfile) in the `tools` directory. If we update `smithyRsVersion` in `config.json` without first updating the container image tag in production release environment, builds will fail because the code generator emits Rust code compliant with the new MSRV, but the container still uses an older compiler for testing.

This PR adds a mechanism to prevent this operational error by:
1. Running git diff between release tags (current `smithyRsVersion` in main vs. PR branch)
2. Checking for any changes under the tools directory
3. Failing the release check workflow if changes are detected

Once the image tag has been updated in the production release environment, we can use the bot user to override and merge the PR to main.

## Testing
- Tested detection by deliberately specifying an old release and reversing the `git diff` argument order to confirm tools change detection ([dry-run](https://github.com/awslabs/aws-sdk-rust/actions/runs/19442709471/job/55629667389#step:5:69))

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.