### PR TITLE
Update smithy-rs version to release-2026-01-14

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "smithyRsVersion": "release-2025-12-08"
+    "smithyRsVersion": "release-2026-01-14"
   }
 }


### PR DESCRIPTION
The following release configuration check [failure](https://github.com/awslabs/aws-sdk-rust/actions/runs/21010967250/job/60405438543?pr=1398#step:5:28) can be ignored:
```
Error: Tools changes detected between release-2025-12-08 and release-2026-01-14
tools/ci-build/Dockerfile
```
The only [changes](https://github.com/smithy-lang/smithy-rs/commits/main/tools/ci-build/Dockerfile) to `Dockerfile` since `release-2025-12-08` were layer shuffles to force image rebuilds and clear accumulated layers (smithy-rs#4456, smithy-rs#4472).

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
