### PR TITLE
Add wasm32-wasi2 target to runner

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -71,14 +71,11 @@ jobs:
           targets: x86_64-unknown-linux-musl
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y musl-dev musl-tools
-      - name: Install cargo component for wasm canary
-        env:
-          # Must be in sync with that specified in `smithy-rs`
-          CARGO_COMPONENT_VERSION: 0.20.0
+      - name: Add wasm32-wasip2 target for wasm canary
         run: |
           rustup toolchain install ${{ env.rust_nightly_version }}
           rustup component add rustfmt
-          cargo +${{ env.rust_nightly_version }} install cargo-component --locked --version ${CARGO_COMPONENT_VERSION}
+          rustup target add wasm32-wasip2
       - name: Compile the canary runner
         working-directory: smithy-rs/tools/ci-cdk/canary-runner
         run: cargo build


### PR DESCRIPTION
Canary has [started failing](https://github.com/awslabs/aws-sdk-rust/actions/runs/21154928510/job/60838069919#step:9:101) due to [our recent release in smithy-rs](https://github.com/smithy-lang/smithy-rs/releases/tag/release-2026-01-14). We need the following to fix this:

- Add `wasm32-wasi2` to the runner as suggested in the error
- Release https://github.com/smithy-lang/smithy-rs/pull/4477

This PR takes care of the first, but since the second bullet is also needed, this PR alone [won't fix the canary](https://github.com/awslabs/aws-sdk-rust/actions/runs/21188275092/job/60948791525#step:9:195).

(In the long run, we should probably want to just update `aws-sdk-rust` to use the `smithy-rs` build image without having to making things in sync).

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
