### PR TITLE
Update smithy-rs to release-2026-02-10

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "smithyRsVersion": "release-2026-02-01"
+    "smithyRsVersion": "release-2026-02-10"
   }
 }


### PR DESCRIPTION
The [failure in Release Configuration Checks](https://github.com/awslabs/aws-sdk-rust/actions/runs/21912989675/job/63272107047?pr=1405) can be ignored, since the image tag has already been updated.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
