### PR TITLE
Update smithy-rs to release-2026-02-16

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "smithyRsVersion": "release-2026-02-10"
+    "smithyRsVersion": "release-2026-02-16"
   }
 }


### PR DESCRIPTION
Release Configuration Checks [failures](https://github.com/awslabs/aws-sdk-rust/actions/runs/22078766716/job/63799498428?pr=1409) can be ignored for this PR. The `sdk-lockfiles` changes don't require updating the ECR image tag since the binary is only used in smithy-rs.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
