### PR TITLE
Update smithy-rs to release-2026-03-16

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "smithyRsVersion": "release-2026-03-02"
+    "smithyRsVersion": "release-2026-03-16"
   }
 }


### PR DESCRIPTION
[Failures](https://github.com/awslabs/aws-sdk-rust/actions/runs/23164917926/job/67302266297?pr=1416) in Release Configuration Checks can be ignored, since neither canary nor `sdk-lockfiles` run in the release pipeline.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
