### PR TITLE
Update CODEOWNERS to reference new aws-sdk-rust-team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-*  @awslabs/rust-sdk-owners
-*  @aws-sdk-rust-ci
+* @awslabs/aws-sdk-rust-team


### PR DESCRIPTION
Replaces old team references with @awslabs/aws-sdk-rust-team.