### PR TITLE
Update smithy-rs to release-2026-05-19

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "smithyRsVersion": "release-2026-04-16"
+    "smithyRsVersion": "release-2026-05-19"
   }
 }


### PR DESCRIPTION
Updates smithy-rs dependency to [release-2026-05-19](https://github.com/smithy-lang/smithy-rs/releases/tag/release-2026-05-19).