### PR TITLE
Update smithy-rs to release-2026-06-11

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "smithyRsVersion": "release-2026-06-01"
+    "smithyRsVersion": "release-2026-06-11"
   }
 }


### PR DESCRIPTION
Updates smithy-rs codegen and runtime dependencies to [release-2026-06-11](https://github.com/smithy-lang/smithy-rs/releases/tag/release-2026-06-11).