### PR TITLE
Update MSRV and nightly for canary

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -7,8 +7,8 @@ on:
     branches:
       - "canary*"
 env:
-  tool_rust_version: 1.91.1
-  rust_nightly_version: nightly-2025-10-18
+  tool_rust_version: 1.94.1
+  rust_nightly_version: nightly-2026-03-20
 
 jobs:
   generate-canary-matrix:


### PR DESCRIPTION
## Motivation and Context

The scheduled canary is failing in the MSRV matrix leg because it still runs Rust 1.91.1 while the current SDK/runtime crates require Rust 1.94.1 after the smithy-rs MSRV bump in smithy-rs#4692.

This updates the canary MSRV and nightly pins to match smithy-rs.

Failed canary example:
https://github.com/awslabs/aws-sdk-rust/actions/runs/29060018459

## Testing

- `git diff --check`
- Manual canary run passed: https://github.com/awslabs/aws-sdk-rust/actions/runs/29125128864

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
